### PR TITLE
Nccl timeout

### DIFF
--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -7,6 +7,7 @@ except ImportError:
     from pkg_resources import packaging  # type: ignore
 
 import time
+from datetime import timedelta
 
 import torch.cuda.nccl as nccl
 import torch.distributed as dist
@@ -105,7 +106,7 @@ def train(
 
 
 def setup():
-    dist.init_process_group("nccl")
+    dist.init_process_group("nccl", timeout=timedelta(seconds=60 * 60))
 
 
 def setup_environ_flags():


### PR DESCRIPTION
When init a large model (e.g. 70b), the model creation + init + post-init (reset_parameters()) could take more than 30mins, which will lead to nccl timeout when doing `low_cpu_mode` as non-0-rank gpus will have to wait for more than 30 mins for rank0 (which exceed default nccl timeout).

We should increase this from 30 mins to 60 mins as what we did before.