### PR TITLE
fix dummy dataloader

### DIFF
--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -29,8 +29,8 @@ def get_dummy_loader(cfg, rank, world_size):
                 self.i += self.l
 
     data = SteadyCounter(
-        cfg.seq_length, 10000
-    )  # 10k vsize since vsize isn't actually in the cfg
+        cfg.seq_length, 32000
+    )  # hardcode 32k vocab size since vocab size isn't available in the cfg
     return torch.utils.data.DataLoader(data, batch_size=cfg.batch_size)
 
 


### PR DESCRIPTION
when using large global batch size, we hit this **RuntimeError: CUDA error: CUBLAS_STATUS_ALLOC_FAILED when calling `cublasCreate(handle)`** error.  Upon checking, this weird error seems to indicate some issue with dataloader distribute data among workers.  Somehow increasing this vsize from 10k to 32k solved the larger bs issue.   This also align with llama's 32k vocab size.