### PR TITLE
Fix weight handling for tuple case

### DIFF
--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -104,7 +104,7 @@ def parse_data_args(datas, weights):
         if isinstance(x, str):
             return [item.strip() for item in x.split(",")]
         elif isinstance(x, (list, tuple)):
-            return list(datas)
+            return list(x)
         elif isinstance(x, (int, float, complex)):
             return [x]
         else:


### PR DESCRIPTION
The recent fix for weight handling included a bug where a weight coming in as a tuple would return `list(data)` rather than `list(weight)`. This corrects the bug. 