### PR TITLE
Enable torch.compile support

### DIFF
--- a/main_training.py
+++ b/main_training.py
@@ -94,6 +94,8 @@ def main(**kwargs):
             else None
         ),
     )
+    model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
+                                    model.config.max_expected_seq_len)
 
     # fsdp activation checkpointing
     if cfg.fsdp_activation_checkpointing:

--- a/main_training.py
+++ b/main_training.py
@@ -110,6 +110,8 @@ def main(**kwargs):
     if cfg.use_torch_compile:
         if rank == 0:
             print(f"--> enabling torch compile...")
+        # the default accumulated_cache_size_limit=64 is not enough for 70b model, so we make it 128 here
+        torch._dynamo.config.accumulated_cache_size_limit = 128
         model = torch.compile(model)
 
     # Optimizer

--- a/main_training.py
+++ b/main_training.py
@@ -95,8 +95,10 @@ def main(**kwargs):
         ),
     )
     # we need this post-fsdp call to avoid graph break with torch.compile, until we figure out a better solution.
-    model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
-                                    model.config.max_expected_seq_len)
+    model.rot_emb.compute_freqs_cis(
+        torch.device("cuda", torch.cuda.current_device()),
+        model.config.max_expected_seq_len,
+    )
 
     # fsdp activation checkpointing
     if cfg.fsdp_activation_checkpointing:

--- a/main_training.py
+++ b/main_training.py
@@ -94,6 +94,9 @@ def main(**kwargs):
             else None
         ),
     )
+    # we need this post-fsdp call to avoid graph break with torch.compile, until we figure out a better solution.
+    model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
+                                    model.config.max_expected_seq_len)
 
     # fsdp activation checkpointing
     if cfg.fsdp_activation_checkpointing:
@@ -105,8 +108,6 @@ def main(**kwargs):
     if cfg.use_torch_compile:
         if rank == 0:
             print(f"--> enabling torch compile...")
-        model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
-                                        model.config.max_expected_seq_len)
         model = torch.compile(model)
 
     # Optimizer

--- a/main_training.py
+++ b/main_training.py
@@ -94,8 +94,6 @@ def main(**kwargs):
             else None
         ),
     )
-    model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
-                                    model.config.max_expected_seq_len)
 
     # fsdp activation checkpointing
     if cfg.fsdp_activation_checkpointing:
@@ -107,12 +105,8 @@ def main(**kwargs):
     if cfg.use_torch_compile:
         if rank == 0:
             print(f"--> enabling torch compile...")
-            if cfg.fsdp_activation_checkpointing:
-                raise ValueError(
-                    "Compile does not yet work well with llama+ac, please"
-                    "either use it without activation checkpointing, or disable"
-                    "compile."
-                )
+        model.rot_emb.compute_freqs_cis(torch.device("cuda", torch.cuda.current_device()),
+                                        model.config.max_expected_seq_len)
         model = torch.compile(model)
 
     # Optimizer


### PR DESCRIPTION
We turned off torch.compile support a while ago due to 1. compile accuracy issue  2. graph break when compiling rope

Now as both are fixed, we should turn this back on to support compile.

Initial experiments shows consistent loss curve over different runs (non-compile vs. compile-with-ac vs. compile-without-ac vs. compile-with-selective-ac). 

<img width="905" alt="image" src="https://github.com/foundation-model-stack/fms-fsdp/assets/20955448/e3067f42-0417-48a7-989f-c25cc3f8fa7c">
