### PR TITLE
fix grow factor in hf conversion

### DIFF
--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -19,10 +19,8 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
             num_attention_heads=hf_config.nheads,
             num_key_value_heads=None if hf_config.kvheads == 0 else hf_config.kvheads,
             num_hidden_layers=hf_config.nlayers,
-            intermediate_size=hf_config.multiple_of
-            * round(
-                int(hf_config.hidden_size * hf_config.hidden_grow_factor)
-                / hf_config.multiple_of
+            intermediate_size=hf_config.multiple_of * (
+                (hf_config.hidden_size + hf_config.multiple_of - 1) // hf_config.multiple_of
             ),
             pad_token_id=(
                 None if hf_config.pad_token_id == -1 else hf_config.pad_token_id

--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -19,8 +19,10 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
             num_attention_heads=hf_config.nheads,
             num_key_value_heads=None if hf_config.kvheads == 0 else hf_config.kvheads,
             num_hidden_layers=hf_config.nlayers,
-            intermediate_size=hf_config.multiple_of * (
-                (hf_config.hidden_size + hf_config.multiple_of - 1) // hf_config.multiple_of
+            intermediate_size=hf_config.multiple_of
+            * (
+                (hf_config.hidden_size + hf_config.multiple_of - 1)
+                // hf_config.multiple_of
             ),
             pad_token_id=(
                 None if hf_config.pad_token_id == -1 else hf_config.pad_token_id

--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -21,7 +21,11 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
             num_hidden_layers=hf_config.nlayers,
             intermediate_size=hf_config.multiple_of
             * (
-                (hf_config.hidden_size + hf_config.multiple_of - 1)
+                (
+                    int(hf_config.hidden_grow_factor * hf_config.hidden_size)
+                    + hf_config.multiple_of
+                    - 1
+                )
                 // hf_config.multiple_of
             ),
             pad_token_id=(


### PR DESCRIPTION
We are using two different "rounding" methods when rounding the up-project dim.

fms: https://github.com/foundation-model-stack/foundation-model-stack/blob/6440fee8007a18878276e65c73a0372cc24faedf/fms/modules/feedforward.py#L181

hf-conversion: https://github.com/foundation-model-stack/foundation-model-stack/blob/050ec05482dd7f9005b6eca8ec13365a927a9a20/fms/models/hf/llama/__init__.py#L77

the first one does up-rounding while the second one does regular rounding.  The second one was used by this repo for converting fms ckpt to hf ckpt, thus we need to make them consistent.