### PR TITLE
add Aim support

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -42,7 +43,7 @@ class train_config:
     use_aim: bool = False
     aim_dir: str = "/lustre/lchu/fms-fsdp"
     aim_project_name: str = "llama"  # project name for a group of runs
-    aim_run_id: str = None  # give a unique id per run, for job resume purpose
+    aim_run_id: Optional[str] = None  # give a unique id per run, for job resume purpose
 
     # compile
     use_torch_compile: bool = False

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -36,14 +36,10 @@ class train_config:
     report_interval: int = 200
     checkpoint_interval: int = 20000
     use_profiler: bool = False
-    use_wandb: bool = False
-    wandb_dir: str = "/lustre/lchu/fms-fsdp"
-    wandb_project_name: str = "llama"  # project name for a group of runs
-    wandb_run_id: str = "aabbccdd"  # give a unique id per run, for job resume purpose
-    use_aim: bool = False
-    aim_dir: str = "/lustre/lchu/fms-fsdp"
-    aim_project_name: str = "llama"  # project name for a group of runs
-    aim_run_id: Optional[str] = None  # give a unique id per run, for job resume purpose
+    tracker: Optional[str] = None  # None, "wandb", "aim"
+    tracker_dir: str = "/lustre/lchu/fms-fsdp"
+    tracker_project_name: str = "llama"  # project name for a group of runs
+    tracker_run_id: Optional[str] = None  # run id, for job resume purpose
 
     # compile
     use_torch_compile: bool = False

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -37,13 +37,11 @@ class train_config:
     use_profiler: bool = False
     use_wandb: bool = False
     wandb_dir: str = "/lustre/lchu/fms-fsdp"
-    wandb_project_name: str = (
-        f"llama-{model_variant}"  # project name for a group of runs
-    )
+    wandb_project_name: str = "llama"  # project name for a group of runs
     wandb_run_id: str = "aabbccdd"  # give a unique id per run, for job resume purpose
     use_aim: bool = False
     aim_dir: str = "/lustre/lchu/fms-fsdp"
-    aim_project_name: str = f"llama-{model_variant}"  # project name for a group of runs
+    aim_project_name: str = "llama"  # project name for a group of runs
     aim_run_id: str = None  # give a unique id per run, for job resume purpose
 
     # compile

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -32,13 +32,19 @@ class train_config:
     grad_clip_thresh: float = 1.0
 
     # profiling and logging
+    report_interval: int = 200
+    checkpoint_interval: int = 20000
     use_profiler: bool = False
     use_wandb: bool = False
     wandb_dir: str = "/lustre/lchu/fms-fsdp"
-    wandb_project_name = f"llama-{model_variant}"
-    wandb_run_id: str = "aabbccdd"  # give a unique id per job, for resume purpose
-    report_interval: int = 200
-    checkpoint_interval: int = 20000
+    wandb_project_name: str = (
+        f"llama-{model_variant}"  # project name for a group of runs
+    )
+    wandb_run_id: str = "aabbccdd"  # give a unique id per run, for job resume purpose
+    use_aim: bool = False
+    aim_dir: str = "/lustre/lchu/fms-fsdp"
+    aim_project_name: str = f"llama-{model_variant}"  # project name for a group of runs
+    aim_run_id: str = None  # give a unique id per run, for job resume purpose
 
     # compile
     use_torch_compile: bool = False

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -32,10 +32,10 @@ class train_config:
     learning_rate: float = 3e-4
     grad_clip_thresh: float = 1.0
 
-    # profiling 
+    # profiling
     use_profiler: bool = False
     profiler_rank0_only: bool = True
-      
+
     # logging
     report_interval: int = 200
     checkpoint_interval: int = 20000

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -47,15 +47,18 @@ def train(
             except ImportError:
                 raise ImportError("tracker is set to wandb but wandb is not installed.")
             if rank == 0:
-                print(
-                    f"--> wandb is enabled! Make sure to pass your wandb api key via WANDB_API_KEY."
-                )
-                wandb.init(
-                    project=project_name,
-                    dir=tracker_dir,
-                    resume="allow",
-                    id=run_id,
-                )
+                print(f"--> wandb is enabled!")
+                try:
+                    wandb.init(
+                        project=project_name,
+                        dir=tracker_dir,
+                        resume="allow",
+                        id=run_id,
+                    )
+                except wandb.errors.UsageError:
+                    raise ValueError(
+                        "wandb failed to init, did you pass your wandb api key via WANDB_API_KEY?"
+                    )
                 wandb.config = hparams
 
         if cfg.tracker == "aim":

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -54,7 +54,7 @@ def train(
 
     if cfg.use_aim:
         try:
-            from aim import Run
+            from aim import Run  # type: ignore
         except ImportError:
             raise ImportError(
                 "use_aim is set to True but aim is not installed. Please install aim to use aim support."

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,3 +15,4 @@ types-setuptools==69.0.0.20240125
 
 # Local import libraries that we don't want to put in global requirements.txt
 wandb==0.16.4
+aim==3.19.1


### PR DESCRIPTION
Similar to [add wandb support](https://github.com/foundation-model-stack/fms-fsdp/pull/44), we now add support for aim.

The usage of aim is almost identical to wandb, except that it does not support a user-defined `run_id` (thus we default `aim_run_id` to None in the config), and resume/continue running can fetch the run_id from existing runs and ingest it in the config.

<img width="1653" alt="image" src="https://github.com/foundation-model-stack/fms-fsdp/assets/20955448/58582869-e669-4f96-bf1d-68a1d5b439e9">
