### PR TITLE
add support for converting compiled model to hf

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ we have learnt from this journey can be found in [Training Details](docs/train_d
 The model trained with this repo is in FMS format, and you might want to convert it
 to Huggingface format so that you can load it natively with Huggingface and leverage Huggingface ecosystem:
 ```bash
-python fms_to_hf.py --model_variant 7b --load_path /path/to/trained/checkpoints --save_path /output/path --tokenizer_name_or_path /path/to/llama/tokenizer
+python fms_to_hf.py --model_variant 7b --nocompiled --load_path /path/to/trained/checkpoints --save_path /output/path --tokenizer_name_or_path /path/to/llama/tokenizer
 ```
 > [!Note]
 > This repo consumes pre-tokenized data thus does not require a tokenizer. However,

--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -95,19 +95,25 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
     return oss_hf_model
 
 
-def main(model_variant, load_path, save_path, tokenizer_name_or_path):
+def main(model_variant, compiled, load_path, save_path, tokenizer_name_or_path):
     print("Initializing model...")
     llama_config = get_model_config(model_variant)
     model = LLaMA(llama_config, orig_init=True)
 
     print(f"Reading state dict from {load_path}")
-    state_dict = {"model_state": model.state_dict()}
+    if not compiled:
+        state_dict = {"model_state": model.state_dict()}
+    else:
+        state_dict = {"model_state": {"_orig_mod": model.state_dict()}}
     load_state_dict(
         state_dict=state_dict, storage_reader=FileSystemReader(load_path), no_dist=True
     )
 
     print("Loading state dict into the model...")
-    model.load_state_dict(state_dict["model_state"])
+    if not compiled:
+        model.load_state_dict(state_dict["model_state"])
+    else:
+        model.load_state_dict(state_dict["model_state"]["_orig_mod"])
 
     print("Converting to HF model..")
     hf_model = convert_to_hf(model)


### PR DESCRIPTION
To address https://github.com/foundation-model-stack/fms-fsdp/issues/59


To convert compiled model, we can run
```python
python fms_to_hf.py --model_variant 7b --compiled --load_path /fsx/lchu/...
```

To convert non-compiled model, we can run
```python
python fms_to_hf.py --model_variant 7b --nocompiled --load_path /fsx/lchu/...
```