### PR TITLE
centralize place for defining block

### DIFF
--- a/fms_fsdp/policies/__init__.py
+++ b/fms_fsdp/policies/__init__.py
@@ -1,4 +1,4 @@
 from .ac_handler import apply_fsdp_checkpointing
 from .mixed_precision import *
 from .param_init import param_init_function
-from .wrapping import get_llama_wrapper
+from .wrapping import get_wrapper

--- a/fms_fsdp/policies/ac_handler.py
+++ b/fms_fsdp/policies/ac_handler.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-from fms.models.llama import LLaMABlock
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointImpl,
     apply_activation_checkpointing,
@@ -14,7 +13,7 @@ non_reentrant_wrapper = partial(
 )
 
 
-def apply_fsdp_checkpointing(model, p):
+def apply_fsdp_checkpointing(model, p, block):
     """
     Apply selective activation checkpointing.
 
@@ -51,7 +50,7 @@ def apply_fsdp_checkpointing(model, p):
         nonlocal block_idx
         nonlocal cut_off
 
-        if isinstance(submodule, LLaMABlock):
+        if isinstance(submodule, block):
             block_idx += 1
             if block_idx * p >= cut_off:
                 cut_off += 1

--- a/fms_fsdp/policies/ac_handler.py
+++ b/fms_fsdp/policies/ac_handler.py
@@ -13,7 +13,7 @@ non_reentrant_wrapper = partial(
 )
 
 
-def apply_fsdp_checkpointing(model, p, block):
+def apply_fsdp_checkpointing(model, block, p):
     """
     Apply selective activation checkpointing.
 

--- a/fms_fsdp/policies/wrapping.py
+++ b/fms_fsdp/policies/wrapping.py
@@ -1,15 +1,14 @@
 import functools
 
-from fms.models.llama import LLaMABlock
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 
 
-def get_llama_wrapper():
-    llama_auto_wrap_policy = functools.partial(
+def get_wrapper(block):
+    auto_wrap_policy = functools.partial(
         transformer_auto_wrap_policy,
         transformer_layer_cls={
-            LLaMABlock,
+            block,
         },
     )
 
-    return llama_auto_wrap_policy
+    return auto_wrap_policy

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -1,4 +1,5 @@
 import os
+from functools import partial
 
 
 try:
@@ -181,7 +182,7 @@ def setup_environ_flags():
 
 
 def get_policies(cfg, rank, block):
-    """Get policies for mixed precision, FSDP wrapping, sharding strategy and param init function."""
+    """Get policies for mixed precision, wrapping, sharding, ac and param init function."""
 
     # mixed precision
     verify_bfloat_support = (
@@ -219,13 +220,22 @@ def get_policies(cfg, rank, block):
     if rank == 0:
         print(f"Sharding strategy = {cfg.sharding_strategy}")
 
+    # ac handler
+    apply_selective_ac = partial(apply_fsdp_checkpointing, block=block)
+
     # param init function
     if cfg.low_cpu_fsdp:
         param_init_fn = param_init_function
     else:
         param_init_fn = None
 
-    return mixed_precision_policy, wrapping_policy, sharding_strategy, param_init_fn
+    return (
+        mixed_precision_policy,
+        wrapping_policy,
+        sharding_strategy,
+        apply_selective_ac,
+        param_init_fn,
+    )
 
 
 def get_profiler(cfg, rank):

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -88,6 +88,7 @@ def train(
 
         optimizer.zero_grad()
         output = model(input)
+        output = output.logits if hasattr(output, "logits") else output
         ce_loss = torch.nn.CrossEntropyLoss()
         loss = ce_loss(output.view(-1, output.size(-1)), label.view(-1).long())
 
@@ -179,7 +180,7 @@ def setup_environ_flags():
     os.environ["NCCL_ASYNC_ERROR_HANDLING"] = str(1)
 
 
-def get_policies(cfg, rank):
+def get_policies(cfg, rank, block):
     """Get policies for mixed precision, FSDP wrapping, sharding strategy and param init function."""
 
     # mixed precision
@@ -204,7 +205,7 @@ def get_policies(cfg, rank):
         mixed_precision_policy = None
 
     # wrapping policy
-    wrapping_policy = get_llama_wrapper()
+    wrapping_policy = get_wrapper(block)
 
     # sharding strategy
     if cfg.sharding_strategy == "fsdp":

--- a/main_training.py
+++ b/main_training.py
@@ -21,6 +21,8 @@ from fms_fsdp.utils.train_utils import (
     train,
 )
 
+from fms.models.llama import LLaMABlock
+
 
 def main(**kwargs):
     # get configs
@@ -51,7 +53,7 @@ def main(**kwargs):
         wrapping_policy,
         sharding_strategy_policy,
         param_init_fn,
-    ) = get_policies(cfg, rank)
+    ) = get_policies(cfg, rank, LLaMABlock)
 
     # get fms model
     llama_config = get_model_config(cfg.model_variant)
@@ -97,7 +99,7 @@ def main(**kwargs):
     if cfg.fsdp_activation_checkpointing:
         if rank == 0:
             print(f"--> applying FSDP activation checkpointing...")
-        policies.apply_fsdp_checkpointing(model, cfg.selective_checkpointing)
+        policies.apply_fsdp_checkpointing(model, cfg.selective_checkpointing, LLaMABlock)
 
     # torch compile
     if cfg.use_torch_compile:

--- a/main_training.py
+++ b/main_training.py
@@ -4,7 +4,7 @@ import os
 import fire
 import torch
 import torch.optim as optim
-from fms.models.llama import LLaMA
+from fms.models.llama import LLaMA, LLaMABlock
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.optim.lr_scheduler import LambdaLR
@@ -20,8 +20,6 @@ from fms_fsdp.utils.train_utils import (
     setup_environ_flags,
     train,
 )
-
-from fms.models.llama import LLaMABlock
 
 
 def main(**kwargs):
@@ -99,7 +97,9 @@ def main(**kwargs):
     if cfg.fsdp_activation_checkpointing:
         if rank == 0:
             print(f"--> applying FSDP activation checkpointing...")
-        policies.apply_fsdp_checkpointing(model, cfg.selective_checkpointing, LLaMABlock)
+        policies.apply_fsdp_checkpointing(
+            model, cfg.selective_checkpointing, LLaMABlock
+        )
 
     # torch compile
     if cfg.use_torch_compile:

--- a/main_training.py
+++ b/main_training.py
@@ -98,7 +98,7 @@ def main(**kwargs):
         if rank == 0:
             print(f"--> applying FSDP activation checkpointing...")
         policies.apply_fsdp_checkpointing(
-            model, cfg.selective_checkpointing, LLaMABlock
+            model, LLaMABlock, cfg.selective_checkpointing
         )
 
     # torch compile

--- a/tests/test_selective_ac.py
+++ b/tests/test_selective_ac.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pytest
 from fms.models.llama import LLaMABlock
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -9,52 +11,54 @@ from fms_fsdp.policies import apply_fsdp_checkpointing
 
 @pytest.mark.parametrize("narrow_model_factory", [15], indirect=True)
 def test_selective_ac(narrow_model_factory):
+    apply_ac = partial(apply_fsdp_checkpointing, block=LLaMABlock)
+
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 0)
+    apply_ac(model, p=0)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 100)
+    apply_ac(model, p=1 / 100)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 5)
+    apply_ac(model, p=1 / 5)
     expected = [False, False, True, False, False] * 3
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 3)
+    apply_ac(model, p=1 / 3)
     expected = [False, True, False] * 5
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 2)
+    apply_ac(model, p=1 / 2)
     expected = [True, False] * 7 + [True]
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 3 / 5)
+    apply_ac(model, p=3 / 5)
     expected = [True, False, True, False, True] * 3
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 2 / 3)
+    apply_ac(model, p=2 / 3)
     expected = [True, False, True] * 5
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 1)
+    apply_ac(model, p=1)
     expected = [True] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, 5 / 3)
+    apply_ac(model, p=5 / 3)
     expected = [True] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, LLaMABlock, -1)
+    apply_ac(model, p=-1)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected

--- a/tests/test_selective_ac.py
+++ b/tests/test_selective_ac.py
@@ -4,56 +4,57 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 
 from fms_fsdp.policies import apply_fsdp_checkpointing
+from fms.models.llama import LLaMA, LLaMABlock
 
 
 @pytest.mark.parametrize("narrow_model_factory", [15], indirect=True)
 def test_selective_ac(narrow_model_factory):
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 0)
+    apply_fsdp_checkpointing(model, LLaMABlock, 0)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 1 / 100)
+    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 100)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 1 / 5)
+    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 5)
     expected = [False, False, True, False, False] * 3
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 1 / 3)
+    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 3)
     expected = [False, True, False] * 5
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 1 / 2)
+    apply_fsdp_checkpointing(model, LLaMABlock, 1 / 2)
     expected = [True, False] * 7 + [True]
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 3 / 5)
+    apply_fsdp_checkpointing(model, LLaMABlock, 3 / 5)
     expected = [True, False, True, False, True] * 3
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 2 / 3)
+    apply_fsdp_checkpointing(model, LLaMABlock, 2 / 3)
     expected = [True, False, True] * 5
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 1)
+    apply_fsdp_checkpointing(model, LLaMABlock, 1)
     expected = [True] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, 5 / 3)
+    apply_fsdp_checkpointing(model, LLaMABlock, 5 / 3)
     expected = [True] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected
 
     model = narrow_model_factory.create()
-    apply_fsdp_checkpointing(model, -1)
+    apply_fsdp_checkpointing(model, LLaMABlock, -1)
     expected = [False] * 15
     assert [isinstance(block, CheckpointWrapper) for block in model.layers] == expected

--- a/tests/test_selective_ac.py
+++ b/tests/test_selective_ac.py
@@ -1,10 +1,10 @@
 import pytest
+from fms.models.llama import LLaMABlock
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     CheckpointWrapper,
 )
 
 from fms_fsdp.policies import apply_fsdp_checkpointing
-from fms.models.llama import LLaMABlock
 
 
 @pytest.mark.parametrize("narrow_model_factory", [15], indirect=True)

--- a/tests/test_selective_ac.py
+++ b/tests/test_selective_ac.py
@@ -4,7 +4,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 
 from fms_fsdp.policies import apply_fsdp_checkpointing
-from fms.models.llama import LLaMA, LLaMABlock
+from fms.models.llama import LLaMABlock
 
 
 @pytest.mark.parametrize("narrow_model_factory", [15], indirect=True)


### PR DESCRIPTION
Currently transformer block is defined and used in a few places including ac_handler module and fsdp_wrapper module.
This PR will centralize these into main (where the model is defined) so it is easier to switch from one model to another.