### PR TITLE
Dataloader updates

### DIFF
--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -74,8 +74,6 @@ def get_data_loader(cfg, rank, world_size):
         rank,
         world_size,
         cfg.sep_token,
-        trainsplit=1,
-        is_val=False,
         min_length=3,
         datasets=datasets,
         weights=weights,

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -11,11 +11,13 @@ import torch
 import torch.utils.data as data
 
 
-# ZX81, cc65, Knuth and H. W. Lewis
+# Entries without attribution were derived empirically and validated for coverage
 LCG_PARAMS = [
-    (2**16 + 1, 75, 74),
-    (2**23, 65793, 4282663),
-    (2**32, 1664525, 1013904223),
+    (2**10, 377, 33),
+    (2**16, 77, 79),
+    (2**23, 65793, 4282663),  # cc65
+    (2**27, 1664525, 1013904223),
+    (2**32, 1664525, 1013904223),  # Knuth and H. W. Lewis
 ]
 
 

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -10,8 +10,13 @@ import pyarrow as pa
 import torch
 import torch.utils.data as data
 
+
 # ZX81, cc65, Knuth and H. W. Lewis
-LCG_PARAMS = [(2 ** 16 + 1, 75, 74), (2 ** 23, 65793, 4282663), (2 ** 32, 1664525, 1013904223)]
+LCG_PARAMS = [
+    (2**16 + 1, 75, 74),
+    (2**23, 65793, 4282663),
+    (2**32, 1664525, 1013904223),
+]
 
 
 """
@@ -541,7 +546,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             docset = {}  # shardid -> (min docid, max docid)
             for i, (shard, frag) in enumerate(shardfrags):
                 ndocs = doc_counts[os.path.join(dataset, shard)]
-                self.docs_per_shard[(dataset,shard)] = ndocs
+                self.docs_per_shard[(dataset, shard)] = ndocs
                 doc_start = (ndocs * frag) // worldsize
                 doc_end = (
                     ndocs * frag + ndocs
@@ -628,7 +633,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 self.delimiter
             ]  # Add delimiter token to signify end of document (used upstream)
         return chunk
-    
+
     def _random_map_docid(self, i, size):
         for params in LCG_PARAMS:
             if size <= params[0]:
@@ -656,7 +661,9 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                     self.epochs_seen += 1
                 self.docset_index = doc_index
                 dataset, shardid, docid = self.get_doc(doc_index)
-                docid = self._random_map_docid(docid, self.docs_per_shard[(dataset, shardid)])
+                docid = self._random_map_docid(
+                    docid, self.docs_per_shard[(dataset, shardid)]
+                )
                 self.dataset_docs_seen[dataset] += 1
                 self.dataset_percent_seen[dataset] = (
                     self.dataset_docs_seen[dataset]
@@ -682,7 +689,9 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             # Load any chunks initially skipped in first doc
             self.docset_index = docset_offset
             dataset, shardid, docid = self.get_doc(docset_offset)
-            docid = self._random_map_docid(docid, self.docs_per_shard[(dataset, shardid)])
+            docid = self._random_map_docid(
+                docid, self.docs_per_shard[(dataset, shardid)]
+            )
             newpath = os.path.join(self.data, dataset, shardid)
             path, reader = self.get_reader(path, newpath, reader)
             doc = reader.get_batch(docid)["tokens"]  # .to_pylist()

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -639,7 +639,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             if size <= params[0]:
                 m, a, c = params
                 break
-        state = i
+        state = (i + self.seed) % size
         while True:
             state = (a * state + c) % m
             if state < size:

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -510,7 +510,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         self.chunksize = max_chunksize
         self.delimiter = delimiter_token
         self.verbose = verbose
-        self.docset = []  # map of doc indices to (dataset, shardid, docid)
+        self.docset = None  # map of doc indices to (dataset, shardid, docid)
         self.fileset = []
         self.datasets = (
             datasets
@@ -617,9 +617,10 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
 
             # Build temp docset with oversample, add to global docset
             doccount = 0
+            new_docset = []
             for shardset in docset:
                 doccount += len(shardset) * self.weights[dataset]
-                self.docset += [shardset] * self.weights[dataset]
+                new_docset += [shardset] * self.weights[dataset]
             self.docs_per_dataset[dataset] = doccount
 
             if verbose:
@@ -629,8 +630,8 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
 
         # Shuffle shardsets across datasets, and flatten
         if shuffle:
-            random.shuffle(self.docset)
-        self.docset = _Docset([key for shardset in self.docset for key in shardset])
+            random.shuffle(new_docset)
+        self.docset = _Docset([key for shardset in new_docset for key in shardset])
 
         self.docset_index = 0
         self.chunk_index = -1

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -688,7 +688,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                     self.epochs_seen += 1
                 self.docset_index = doc_index
                 # Map doc id to dataset, shard, id in file
-                dataset, shardid, docid = self._get_doc(doc_index)
+                dataset, shardid, docid = self._get_docid(doc_index)
                 # Map id in file to new (consistently) shuffled id
                 docid = self._random_map_docid(
                     docid, self.docs_per_shard[(dataset, shardid)]
@@ -717,7 +717,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
 
             # Load any chunks initially skipped in first doc
             self.docset_index = docset_offset
-            dataset, shardid, docid = self._get_doc(docset_offset)
+            dataset, shardid, docid = self._get_docid(docset_offset)
             docid = self._random_map_docid(
                 docid, self.docs_per_shard[(dataset, shardid)]
             )

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -609,7 +609,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         self.dataset_tokens_seen = {d: 0 for d in self.datasets}
         self.dataset_docs_seen = {d: 0 for d in self.datasets}
         self.dataset_percent_seen = {d: 0 for d in self.datasets}
-        self.lcg_state = seed
+        self.lcg_state = seed + rank
         # self.docs_seen: Dict[Any, int] = {}  # (dataset, shard, i) -> # times seen
 
         self.state_params = [

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -683,7 +683,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             if size <= params[0]:
                 m, a, c = params
                 break
-        state = (i + self.seed) % size
+        state = (i + self.seed + size) % m
         while True:
             state = (a * state + c) % m
             if state < size:

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -683,7 +683,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             if size <= params[0]:
                 m, a, c = params
                 break
-        state = (i + self.seed + size) % m
+        state = i
         while True:
             state = (a * state + c) % m
             if state < size:

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -4,7 +4,7 @@ import math
 import os
 import random
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union, Sized
 
 import pyarrow as pa
 import torch
@@ -400,7 +400,7 @@ class Buffer_Dataset(_Wrapper_Dataset):
             yield out
 
 
-class _Docset:
+class _Docset(Sized):
     def __init__(self, docset):
         # docset is a list of tuples (dataset, shardid, docid)
         d = OrderedDict()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -615,8 +615,8 @@ def test_streaming_doc_sample():
         max_chunksize=101,
     )
     assert (
-        len(dataset.docset) == 34 * 5
-    ), f"Sampled data of length {len(dataset.docset)} does not match expected value {34*5}"
+        len(dataset.docset_) == 34 * 5
+    ), f"Sampled data of length {len(dataset.docset_)} does not match expected value {34*5}"
 
     # Each dataset has 100 entries, 33.1% rounds up to 34 entries
     dataset = Streaming_Doc_Dataset(
@@ -630,8 +630,8 @@ def test_streaming_doc_sample():
         max_chunksize=101,
     )
     assert (
-        len(dataset.docset) == 34 * 5
-    ), f"Sampled data of length {len(dataset.docset)} does not match expected value {34*5}"
+        len(dataset.docset_) == 34 * 5
+    ), f"Sampled data of length {len(dataset.docset_)} does not match expected value {34*5}"
 
 
 # SCALABLE_DATASET TESTS

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -310,7 +310,6 @@ def basic_loader(
         rank,
         worldsize,
         -1,
-        trainsplit=1,
         datasets=datasets,
         weights=weights,
         max_chunksize=max_chunksize,
@@ -326,7 +325,6 @@ def basic_sampler(
         rank,
         worldsize,
         -1,
-        trainsplit=1,
         datasets=datasets,
         weights=weights,
         max_chunksize=max_chunksize,
@@ -346,7 +344,6 @@ def basic_scalable(
         rank,
         worldsize,
         -1,
-        trainsplit=1,
         datasets=datasets,
         weights=weights,
         max_chunksize=max_chunksize,
@@ -368,7 +365,6 @@ def basic_scalable_sampler(
         rank,
         worldsize,
         -1,
-        trainsplit=1,
         datasets=datasets,
         weights=weights,
         max_chunksize=max_chunksize,
@@ -520,7 +516,6 @@ def test_multi_reload_stress():
             i,
             3,
             -1,
-            trainsplit=1,
             datasets=["dataset_1", "dataset_2"],
             weights=[3, 5],
             max_chunksize=17,
@@ -537,7 +532,6 @@ def test_multi_reload_stress():
             i,
             3,
             -1,
-            trainsplit=1,
             datasets=["dataset_1", "dataset_2"],
             weights=[3, 5],
             max_chunksize=17,
@@ -554,7 +548,6 @@ def test_multi_reload_stress():
             3,
             -1,
             n_logical_shards=15,
-            trainsplit=1,
             datasets=["dataset_1", "dataset_2"],
             weights=[3, 5],
             max_chunksize=17,
@@ -572,7 +565,6 @@ def test_multi_reload_stress():
             3,
             -1,
             n_logical_shards=15,
-            trainsplit=1,
             datasets=["dataset_1", "dataset_2"],
             weights=[3, 5],
             max_chunksize=17,
@@ -598,42 +590,6 @@ def test_multi_reload_stress():
     multi_reload_stress_check(lambda: d7(d4()))
 
 
-# STREAMING_DOC_DATASET TESTS
-
-
-def test_streaming_doc_sample():
-    # Check that % grab, grabs precisely and rounds correctly (multi dataset, weighted, single loader)
-
-    dataset = Streaming_Doc_Dataset(
-        tmpdir.name,
-        0,
-        1,
-        -1,
-        trainsplit=0.34,
-        datasets=["dataset_1", "dataset_2"],
-        weights=[2, 3],
-        max_chunksize=101,
-    )
-    assert (
-        len(dataset.docset_) == 34 * 5
-    ), f"Sampled data of length {len(dataset.docset_)} does not match expected value {34*5}"
-
-    # Each dataset has 100 entries, 33.1% rounds up to 34 entries
-    dataset = Streaming_Doc_Dataset(
-        tmpdir.name,
-        0,
-        1,
-        -1,
-        trainsplit=0.331,
-        datasets=["dataset_1", "dataset_2"],
-        weights=[2, 3],
-        max_chunksize=101,
-    )
-    assert (
-        len(dataset.docset_) == 34 * 5
-    ), f"Sampled data of length {len(dataset.docset_)} does not match expected value {34*5}"
-
-
 # SCALABLE_DATASET TESTS
 
 
@@ -646,7 +602,6 @@ def test_scalable_partitioning():
     for layer in [Scalable_Shard_Dataset, Sampling_Dataset]:
         kwargs = {
             "n_logical_shards": 12,
-            "trainsplit": 1,
             "datasets": ["dataset_1"],
             "weights": [1],
             "max_chunksize": 200,
@@ -666,7 +621,6 @@ def test_scalable_partitioning():
 
         kwargs = {
             "n_logical_shards": 12,
-            "trainsplit": 1,
             "datasets": ["dataset_1"],
             "weights": [1],
             "max_chunksize": 200,
@@ -731,7 +685,6 @@ def test_scalable_shard_reload_scale():
             2,
             -1,
             n_logical_shards=8,
-            trainsplit=1,
             datasets=["dataset_1"],
             weights=[1],
             max_chunksize=40,
@@ -757,7 +710,6 @@ def test_scalable_shard_reload_scale():
             4,
             -1,
             n_logical_shards=8,
-            trainsplit=1,
             datasets=["dataset_1"],
             weights=[1],
             max_chunksize=40,
@@ -794,7 +746,6 @@ def test_scalable_sampler_reload_scale():
             2,
             -1,
             n_logical_shards=8,
-            trainsplit=1,
             datasets=["dataset_1"],
             weights=[1],
             max_chunksize=40,
@@ -821,7 +772,6 @@ def test_scalable_sampler_reload_scale():
             4,
             -1,
             n_logical_shards=8,
-            trainsplit=1,
             datasets=["dataset_1"],
             weights=[1],
             max_chunksize=40,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,963 @@
+import functools
+import os
+import tempfile
+from collections import Counter
+from copy import deepcopy
+from itertools import chain
+
+import pyarrow as pa
+import torch
+
+from fms_fsdp.utils.dataset_utils import *
+
+
+# Generates test data in a temp directory, and returns that tempdir object.
+# (file path can be retrieved via tempdir.name)
+# Two dataset folders: one has a large shardfile (100x100), other has two small shardfiles (50x50)
+def generate_sequential_multidata():
+    tmpdir = tempfile.TemporaryDirectory()
+    schema = pa.schema([pa.field("tokens", pa.uint32())])
+
+    os.mkdir(os.path.join(tmpdir.name, "dataset_1"))
+    os.mkdir(os.path.join(tmpdir.name, "dataset_2"))
+    with pa.ipc.new_file(
+        os.path.join(tmpdir.name, "dataset_1/fullshard.arrow"), schema
+    ) as writer:
+        for i in range(100):
+            out = list(range(i * 100, i * 100 + 100))
+            writer.write(pa.record_batch([out], schema=schema))
+
+    with pa.ipc.new_file(
+        os.path.join(tmpdir.name, "dataset_2/quartershard_1.arrow"), schema
+    ) as writer:
+        for i in range(50):
+            out = list(range(i * 50, i * 50 + 50))
+            writer.write(pa.record_batch([out], schema=schema))
+
+    with pa.ipc.new_file(
+        os.path.join(tmpdir.name, "dataset_2/quartershard_2.arrow"), schema
+    ) as writer:
+        for i in range(50):
+            out = list(range(2500 + i * 50, 2500 + i * 50 + 50))
+            writer.write(pa.record_batch([out], schema=schema))
+
+    # Make metadata file
+    os.mkdir(os.path.join(tmpdir.name, "meta"))
+    f = open(os.path.join(tmpdir.name, "meta", "combined_counts.csv"), "w")
+    f.write("dataset/filename,documents,tokens\n")
+    f.write("/dataset_1/fullshard.arrow,100,10000\n")
+    f.write("/dataset_2/quartershard_1.arrow,50,2500\n")
+    f.write("/dataset_2/quartershard_2.arrow,50,2500\n")
+    f.close()
+
+    return tmpdir
+
+
+# Make mock data for re-use. Returns directory path.
+tmpdir = generate_sequential_multidata()
+
+
+# REPEATED CHECKS
+# Checks take a dataset definition (and any other args), instantiate it, and perform a single unit test
+# For X_check see corresponding test_X
+
+
+def count_check(d, dataset, ntok, ndoc, alldoc, allpercent):
+    # Check that tokens tracked matches tokens seen, and docs tracked matches docs seen
+    # d is a lambda for a fully-defined dataset (i.e. d() instantiates the dataset)
+    assert (
+        d.dataset_tokens_seen[dataset] == ntok
+    ), f"Tokens tracked {d.dataset_tokens_seen[dataset]} failed to match target {ntok}"
+    # for k in d.docs_seen.keys():
+    #     if k[0] == dataset:
+    #         assert d.docs_seen[k] == ndoc, f"Document {k} appeared {d.docs_seen[k]} times rather than {ndoc}"
+    # assert (
+    #     d.dataset_docs_seen[dataset] == alldoc
+    # ), f"Total document count {d.dataset_docs_seen[dataset]} does not match target {alldoc}"
+    coverage = d.dataset_percent_seen[dataset]
+    assert (
+        abs(coverage - allpercent) < 1e-4
+    ), f"Percent coverage {coverage} is not within 1e-4 of {allpercent}"
+
+
+def multi_reload_stress_check(d):
+    # Perform the reload stress test for different numbers of steps before and after checkpoint
+    # d is a lambda for a fully-defined dataset (i.e. d() instantiates the dataset)
+
+    def reload_stress(datasets, datasets2, steps1, steps2):
+        # Perform the 5-step reload stress test (see test_reload_stress_all)
+
+        loaders = [iter(d) for d in datasets]
+
+        for i in range(steps1):
+            [next(l) for l in loaders]
+
+        states = [deepcopy(d.state_dict()) for d in datasets]
+
+        [d.load_state_dict(states) for d in datasets2]
+
+        loaders2 = [iter(d) for d in datasets2]
+
+        for k in range(steps2):
+            for i in range(3):
+                out1 = next(loaders[i])
+                out2 = next(loaders2[i])
+                assert len(out1) == len(
+                    out2
+                ), f"Dataloader {i} in step {k} has mismatched length: {len(out1)} vs {len(out2)}"
+                for j in range(len(out1)):
+                    assert (
+                        out1[j] == out2[j]
+                    ), f"Dataloader {i} in step {k} has mismatched token in position {j}: {out1[j]} vs {out2[j]}"
+
+    steps1 = [0, 1, 10, 100, 1000]
+    steps2 = [100, 200, 300, 400, 500]
+    for i in range(len(steps1)):
+        # Reset between tests (instantiate fresh datasets)
+        reload_stress(d(), d(), steps1[i], steps2[i])
+
+
+def single_epoch_check(d, do_countcheck=False):
+    # For a single loader on dataset_1, check that every doc appears once per epoch
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset = d(datasets=["dataset_1"])
+    ins = []
+    loader = iter(dataset)
+    for i in range(100):
+        out = next(loader)
+        ins.append(out[0])
+
+    for i in range(100):
+        assert (
+            i * 100 in ins
+        ), f"Line starting with {i * 100} failed to appear in generated data"
+
+    if do_countcheck:
+        # Check state flags tracking correctly
+        count_check(dataset, "dataset_1", 100 * 100, 1, 100, 100)
+
+
+def two_epoch_check(d, do_countcheck=False):
+    # For a single loader on dataset_1, check that every doc appears twice per two epochs
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset = d(datasets=["dataset_1"])
+    ins = []
+    loader = iter(dataset)
+    for i in range(100 * 2):
+        out = next(loader)
+        ins.append(out[0])
+
+    for i in range(100):
+        key = ins.pop(0)
+        assert (
+            key in ins
+        ), f"Line starting with {key} failed to appear a second time in generated data"
+
+    if do_countcheck:
+        # Check state flags tracking correctly
+        count_check(dataset, "dataset_1", 100 * 100 * 2, 2, 200, 200)
+
+
+def chunk_check(d, do_countcheck=False):
+    # For a single loader on dataset_1, check that every doc chunks properly and that all chunks appear in one epoch
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset = d(datasets=["dataset_1"], max_chunksize=50)
+    ins = []
+    loader = iter(dataset)
+    for i in range(300):
+        out = next(loader)
+        if i % 3 != 2:
+            assert (
+                len(out) == 50
+            ), f"Line length {len(out)} does not match chunk size 50"
+        else:
+            assert (
+                out[0] == -1
+            ), f"Chunk 3 of document {i} is not delimiter token, but {out}"
+        ins.append(out[0])
+
+    for i in range(200):
+        assert (
+            i * 50 in ins
+        ), f"Chunk starting with {i * 50} failed to appear in generated data"
+
+    if do_countcheck:
+        count_check(dataset, "dataset_1", 100 * 100, 1, 100, 100)
+
+
+def two_loader_check(d, do_countcheck=False):
+    # For two loaders on dataset_1, check that every doc appears once per epoch, collectively
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset1 = d(datasets=["dataset_1"], worldsize=2, rank=0)
+    dataset2 = d(datasets=["dataset_1"], worldsize=2, rank=1)
+    ins = []
+    loader = iter(dataset1)
+    for i in range(50):
+        out = next(loader)
+        ins.append(out[0])
+    loader = iter(dataset2)
+    for i in range(50):
+        out = next(loader)
+        ins.append(out[0])
+
+    for i in range(100):
+        assert (
+            i * 100 in ins
+        ), f"Line starting with {i * 100} failed to appear in generated data"
+
+    if do_countcheck:
+        count_check(dataset1, "dataset_1", 50 * 100, 1, 50, 100)
+        count_check(dataset2, "dataset_1", 50 * 100, 1, 50, 100)
+
+
+def multi_file_check(d, do_countcheck=False):
+    # For a single loader on dataset 2, check that every doc appears once per epoch
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset = d(datasets=["dataset_2"])
+    ins = []
+    loader = iter(dataset)
+    for i in range(100):
+        out = next(loader)
+        ins.append(out[0])
+
+    for i in range(100):
+        assert (
+            i * 50 in ins
+        ), f"Line starting with {i * 50} failed to appear in generated data"
+
+    if do_countcheck:
+        count_check(dataset, "dataset_2", 100 * 50, 1, 100, 100)
+
+
+def chunk_weight_check(w1, w2, d, do_countcheck=False):
+    # For a single loader on combined datasets, with given oversamples, chunksize 50: check that chunks appear the proper number of times
+    # d is a lambda for a dataset (i.e. d() instantiates the dataset)
+    dataset = d(datasets=["dataset_1", "dataset_2"], weights=[w1, w2], max_chunksize=50)
+    ins = []
+    loader = iter(dataset)
+    for i in range(3 * w1 * 100 + 2 * w2 * 100):
+        out = next(loader)
+        if len(out) > 1:
+            ins.append(out[0])
+
+    check = Counter(ins)
+    for i in range(200):
+        if i < 100:
+            assert (
+                check[i * 50] == w1 + w2
+            ), f"Chunk starting with {i * 50} appeared {check[i*50]} times rather than {w1+w2}"
+        else:
+            assert (
+                check[i * 50] == w1
+            ), f"Chunk starting with {i * 50} appeared {check[i*50]} times rather than {w1}"
+
+    # Check state flags tracking correctly
+    if do_countcheck:
+        count_check(dataset, "dataset_1", 100 * 100 * w1, w1, 100 * w1, 100)
+        count_check(dataset, "dataset_2", 100 * 50 * w2, w2, 100 * w2, 100)
+
+
+def scalable_shard_reload_epoch_check(loader):
+    # Single shard, two loaders: do exactly 1/3 of an epoch, checkpoint, reload to same number of workers.
+    # Complete the epoch and verify that no loaded chunks are revisiting old chunks.
+    datasets = [
+        loader(
+            rank=i,
+            worldsize=2,
+            max_chunksize=40,
+        )
+        for i in range(2)
+    ]  # Length 300
+    loaders = [iter(d) for d in datasets]
+
+    ins = []
+    for _ in range(50):
+        out = next(loaders[0])
+        ins.append(out[0])
+    for _ in range(50):
+        out = next(loaders[1])
+        ins.append(out[0])
+
+    states = [d.state_dict() for d in datasets]
+
+    datasets2 = [
+        loader(
+            rank=i,
+            worldsize=2,
+            max_chunksize=40,
+        )
+        for i in range(2)
+    ]  # Length 300
+    [d.load_state_dict(states) for d in datasets2]
+    loaders2 = [iter(d) for d in datasets2]
+
+    for j in range(100):
+        for i in range(2):
+            out = next(loaders2[i])
+            assert (
+                out[0] not in ins
+            ), f"Step {j+1}, dataset {i+1}: chunk starting with {out[0]} has already appeared in the epoch"
+
+
+# BASE DATASET TESTS
+
+
+def basic_loader(
+    rank=0, worldsize=1, datasets=["dataset_1"], weights=[1], max_chunksize=1000
+):
+    return Streaming_Doc_Dataset(
+        tmpdir.name,
+        rank,
+        worldsize,
+        -1,
+        trainsplit=1,
+        datasets=datasets,
+        weights=weights,
+        max_chunksize=max_chunksize,
+    )
+
+
+def basic_sampler(
+    rank=0, worldsize=1, datasets=["dataset_1"], weights=[1], max_chunksize=1000
+):
+    return Sampling_Dataset(
+        tmpdir.name,
+        Streaming_Doc_Dataset,
+        rank,
+        worldsize,
+        -1,
+        trainsplit=1,
+        datasets=datasets,
+        weights=weights,
+        max_chunksize=max_chunksize,
+    )
+
+
+def basic_scalable(
+    rank=0,
+    worldsize=1,
+    datasets=["dataset_1"],
+    weights=[1],
+    max_chunksize=1000,
+    n_logical_shards=7,
+):
+    return Scalable_Shard_Dataset(
+        tmpdir.name,
+        rank,
+        worldsize,
+        -1,
+        trainsplit=1,
+        datasets=datasets,
+        weights=weights,
+        max_chunksize=max_chunksize,
+        n_logical_shards=n_logical_shards,
+    )
+
+
+def basic_scalable_sampler(
+    rank=0,
+    worldsize=1,
+    datasets=["dataset_1"],
+    weights=[1],
+    max_chunksize=1000,
+    n_logical_shards=7,
+):
+    return Sampling_Dataset(
+        tmpdir.name,
+        Scalable_Shard_Dataset,
+        rank,
+        worldsize,
+        -1,
+        trainsplit=1,
+        datasets=datasets,
+        weights=weights,
+        max_chunksize=max_chunksize,
+        n_logical_shards=n_logical_shards,
+    )
+
+
+def test_single_epoch():
+    # Single shard, single loader: every line appears once in an epoch
+    single_epoch_check(basic_loader, True)
+    single_epoch_check(basic_scalable)
+    single_epoch_check(basic_sampler)
+    single_epoch_check(basic_scalable_sampler)
+
+
+def test_two_epoch():
+    # Single shard, single loader: every line appears twice in two epochs
+    two_epoch_check(basic_loader, True)
+    two_epoch_check(basic_scalable)
+    two_epoch_check(basic_sampler)
+    two_epoch_check(basic_scalable_sampler)
+
+
+def test_chunk():
+    # Single shard, single loader, two chunks/doc plus a delimiter token: every chunk appears once in an epoch
+    chunk_check(functools.partial(basic_loader, max_chunksize=50), True)
+    chunk_check(functools.partial(basic_scalable, max_chunksize=50))
+    chunk_check(functools.partial(basic_sampler, max_chunksize=50))
+    chunk_check(functools.partial(basic_scalable_sampler, max_chunksize=50))
+
+
+def test_two_loader():
+    # Single shard, two loaders: every line appears once per epoch, collectively
+    two_loader_check(basic_loader, True)
+    two_loader_check(functools.partial(basic_scalable, n_logical_shards=8))
+    two_loader_check(basic_sampler)
+    two_loader_check(functools.partial(basic_scalable_sampler, n_logical_shards=8))
+
+
+def test_multi_file():
+    # Multiple shard files, single loader: every line appears once in an epoch
+    multi_file_check(basic_loader, True)
+    multi_file_check(basic_scalable)
+    multi_file_check(basic_sampler)
+    multi_file_check(basic_scalable_sampler)
+
+
+def test_reload_epoch():
+    # Single shard, two loaders: check that reloading mid-epoch does not cause data to repeat while finishing the epoch
+    scalable_shard_reload_epoch_check(basic_loader)
+    scalable_shard_reload_epoch_check(
+        functools.partial(basic_scalable, n_logical_shards=8)
+    )
+    scalable_shard_reload_epoch_check(basic_sampler)
+    scalable_shard_reload_epoch_check(
+        functools.partial(basic_scalable_sampler, n_logical_shards=8)
+    )
+
+
+# SUBDATASET WEIGHTING CHECKS
+
+
+def test_weight():
+    """
+    A test for base, non-wrapper datasets using oversampling (currently Streaming_Doc and Scalable_Shard).
+    On the full dataset, with varying weights, on a single worker: with chunksize 50, run one epoch.
+    Verify that first half of dataset_1 is replicated by dataset_2, and second half is not, with appropriate ratios.
+    """
+    w1 = [1, 2, 4]
+    w2 = [1, 3, 7]
+    for i in w1:
+        for j in w2:
+            # Test chunk weights on doc dataloader (single epoch)
+            doc_dataset = functools.partial(
+                basic_loader,
+                datasets=["dataset_1", "dataset_2"],
+                weights=[i, j],
+                max_chunksize=50,
+            )
+            chunk_weight_check(i, j, doc_dataset, True)
+            # Test chunk weights on scalable dataloader (single epoch)
+            shard_dataset = functools.partial(
+                basic_scalable,
+                datasets=["dataset_1", "dataset_2"],
+                weights=[i, j],
+                max_chunksize=50,
+            )
+            chunk_weight_check(i, j, shard_dataset)
+
+
+def test_sampler_rates():
+    """
+    A test for base, non-wrapper datasets using percentage sampling (currently Sampling and Scalable_Sampling).
+    On the full dataset, with varying weights, on a single worker: verify that loaders pull subdatasets at regular intervals
+    (verifying that they're regularly picking the most-underviewed subdataset at each step).
+    """
+    weights = [[1, 1], [2, 1], [2, 3], [2, 5]]
+    target_rate = [3, 2, 4, 6]
+    burnin = [3, 0, 4, 6]
+
+    # Dataset1 docs are twice the length of dataset2. Burnin required to reach equilibrium.
+    # Expected sequences for each case are:
+    # 2 1 2 1 2 2 (1 2 2)...
+    # 1 2 1 2 (1 2)...
+    # 2 1 2 2 1 2 2 2 (1 2 2 2)...
+    # 2 1 2 2 2 2 1 2 2 2 2 2 (1 2 2 2 2 2)...
+
+    def check_rates(w, t, b, m):
+        s = []
+        d = m(datasets=["dataset_1", "dataset_2"], weights=w)
+        l = iter(d)
+        for i in range(b):
+            s.append(len(next(l)))
+        for i in range(100):
+            out = next(l)
+            s.append(len(out))
+            if i % t == 0:
+                assert (
+                    len(out) == 101
+                ), f"Output {i} length {len(out)} does not match expected 101. Sequence so far: {s}"
+            else:
+                assert (
+                    len(out) == 51
+                ), f"Output {i} length {len(out)} does not match expected 51. Sequence so far: {s}"
+
+    for i in range(3):
+        for m in [basic_sampler, basic_scalable_sampler]:
+            check_rates(weights[i], target_rate[i], burnin[i], m)
+
+
+# STRESS TEST
+
+
+def test_multi_reload_stress():
+    """
+    For each nontrivial layer of the dataset pipeline:
+        For each combo of steps:
+            Initialize two identical datasets
+            Take n steps with the first one
+            Save checkpoint
+            Load checkpoint into second dataset
+            Take k steps with both datasets, check that outputs are identical
+    Parameters are chosen to ensure messy states (non-divisible chunk sizes, shard numbers, n_workers, buffer_length, etc.)
+    """
+    # Shard doc dataset
+    d1 = lambda: [
+        Streaming_Doc_Dataset(
+            tmpdir.name,
+            i,
+            3,
+            -1,
+            trainsplit=1,
+            datasets=["dataset_1", "dataset_2"],
+            weights=[3, 5],
+            max_chunksize=17,
+        )
+        for i in range(3)
+    ]
+    multi_reload_stress_check(d1)
+
+    # Sampling dataset
+    d2 = lambda: [
+        Sampling_Dataset(
+            tmpdir.name,
+            Streaming_Doc_Dataset,
+            i,
+            3,
+            -1,
+            trainsplit=1,
+            datasets=["dataset_1", "dataset_2"],
+            weights=[3, 5],
+            max_chunksize=17,
+        )
+        for i in range(3)
+    ]
+    multi_reload_stress_check(d2)
+
+    # Scalable shard dataset
+    d3 = lambda: [
+        Scalable_Shard_Dataset(
+            tmpdir.name,
+            i,
+            3,
+            -1,
+            n_logical_shards=15,
+            trainsplit=1,
+            datasets=["dataset_1", "dataset_2"],
+            weights=[3, 5],
+            max_chunksize=17,
+        )
+        for i in range(3)
+    ]
+    multi_reload_stress_check(d3)
+
+    # Nested scalable sampling dataset
+    d4 = lambda: [
+        Sampling_Dataset(
+            tmpdir.name,
+            Scalable_Shard_Dataset,
+            i,
+            3,
+            -1,
+            n_logical_shards=15,
+            trainsplit=1,
+            datasets=["dataset_1", "dataset_2"],
+            weights=[3, 5],
+            max_chunksize=17,
+        )
+        for i in range(3)
+    ]
+    multi_reload_stress_check(d4)
+
+    # Add buffer dataset
+    d5 = lambda x: [Buffer_Dataset(d, 73, pack_hard=True, bos_token=-1) for d in x]
+    # Stress test buffer + all bases
+    for d in [d1, d2, d3, d4]:
+        multi_reload_stress_check(lambda: d5(d()))
+
+    # # Add PLM dataset
+    # d6 = lambda x: [PLM_Dataset(d, -3, -2) for d in x]
+    # # plm / buffer / sample / scale / doc pipeline
+    # multi_reload_stress_check(lambda: d6(d5(d4())))
+
+    # Add preload buffer dataset
+    d7 = lambda x: [Preload_Buffer_Dataset(d, 99) for d in x]
+    # preload / sample / scale / doc pipeline
+    multi_reload_stress_check(lambda: d7(d4()))
+
+
+# STREAMING_DOC_DATASET TESTS
+
+
+def test_streaming_doc_sample():
+    # Check that % grab, grabs precisely and rounds correctly (multi dataset, weighted, single loader)
+
+    dataset = Streaming_Doc_Dataset(
+        tmpdir.name,
+        0,
+        1,
+        -1,
+        trainsplit=0.34,
+        datasets=["dataset_1", "dataset_2"],
+        weights=[2, 3],
+        max_chunksize=101,
+    )
+    assert (
+        len(dataset.docset) == 34 * 5
+    ), f"Sampled data of length {len(dataset.docset)} does not match expected value {34*5}"
+
+    # Each dataset has 100 entries, 33.1% rounds up to 34 entries
+    dataset = Streaming_Doc_Dataset(
+        tmpdir.name,
+        0,
+        1,
+        -1,
+        trainsplit=0.331,
+        datasets=["dataset_1", "dataset_2"],
+        weights=[2, 3],
+        max_chunksize=101,
+    )
+    assert (
+        len(dataset.docset) == 34 * 5
+    ), f"Sampled data of length {len(dataset.docset)} does not match expected value {34*5}"
+
+
+# SCALABLE_DATASET TESTS
+
+
+def test_scalable_partitioning():
+    """
+    Test that partitioning occurs correctly when rescaling up or down, including to non-multiples of the original
+    physical worker count. Start with 4 workers with 12 logical shards, and for each of [1,2,3,6,12], verify that:
+    1) no overlap exists between workers and 2) in over one epoch's worth of steps, each data point appears at least once
+    """
+    for layer in [Scalable_Shard_Dataset, Sampling_Dataset]:
+        kwargs = {
+            "n_logical_shards": 12,
+            "trainsplit": 1,
+            "datasets": ["dataset_1"],
+            "weights": [1],
+            "max_chunksize": 200,
+        }
+        datasets = [
+            layer(tmpdir.name, Scalable_Shard_Dataset, i, 4, -1, **kwargs)
+            if layer == Sampling_Dataset
+            else layer(tmpdir.name, i, 4, -1, **kwargs)
+            for i in range(4)
+        ]  # 25 steps per epoch
+        loaders = [iter(d) for d in datasets]
+
+        for _ in range(50):
+            [next(l) for l in loaders]
+
+        states = [d.state_dict() for d in datasets]
+
+        kwargs = {
+            "n_logical_shards": 12,
+            "trainsplit": 1,
+            "datasets": ["dataset_1"],
+            "weights": [1],
+            "max_chunksize": 200,
+        }
+        for worldsize in [1, 2, 3, 6, 12]:
+            datasets = [
+                layer(
+                    tmpdir.name,
+                    Scalable_Shard_Dataset,
+                    i,
+                    worldsize,
+                    -1,
+                    **kwargs,
+                )
+                if layer == Sampling_Dataset
+                else layer(
+                    tmpdir.name,
+                    i,
+                    worldsize,
+                    -1,
+                    **kwargs,
+                )
+                for i in range(worldsize)
+            ]
+            [d.load_state_dict(states) for d in datasets]
+            loaders = [iter(d) for d in datasets]
+            outs = [[] for _ in datasets]
+            steps = int(100 / worldsize * 1.25)
+            for i in range(steps):
+                for j, l in enumerate(loaders):
+                    outs[j].append(next(l)[0])
+
+            # Check for non-overlap
+            for i in range(len(datasets)):
+                for j in range(i + 1, len(datasets)):
+                    outi = set(outs[i])
+                    outj = set(outs[j])
+                    for t in outi:
+                        assert (
+                            t not in outj
+                        ), f"Overlapping value {t} detected in worker {i} and {j}: {outi}, {outj}"
+                    for t in outj:
+                        assert (
+                            t not in outi
+                        ), f"Overlapping value {t} detected in worker {i} and {j}: {outi}, {outj}"
+
+            # Check for completion
+            allout = set(chain(*outs))
+            for i in range(100):
+                assert i * 100 in allout, f"Token {i*100} missing from outputs {allout}"
+
+
+def test_scalable_shard_reload_scale():
+    """
+    As test_reload_epoch, but in this case we scale from 2 workers to 4 (complete 1/3 epoch, reload, finish without duplication).
+    Because logical shards won't all be the exact same length when checkpointed, we complete the epoch of the shortest of the new workers.
+    """
+    datasets = [
+        Scalable_Shard_Dataset(
+            tmpdir.name,
+            i,
+            2,
+            -1,
+            n_logical_shards=8,
+            trainsplit=1,
+            datasets=["dataset_1"],
+            weights=[1],
+            max_chunksize=40,
+        )
+        for i in range(2)
+    ]  # Length 300
+    loaders = [iter(d) for d in datasets]
+
+    ins = []
+    for _ in range(50):
+        out = next(loaders[0])
+        ins.append(out[0])
+    for _ in range(50):
+        out = next(loaders[1])
+        ins.append(out[0])
+
+    states = [d.state_dict() for d in datasets]
+
+    datasets2 = [
+        Scalable_Shard_Dataset(
+            tmpdir.name,
+            i,
+            4,
+            -1,
+            n_logical_shards=8,
+            trainsplit=1,
+            datasets=["dataset_1"],
+            weights=[1],
+            max_chunksize=40,
+        )
+        for i in range(4)
+    ]  # Length 300
+    [d.load_state_dict(states) for d in datasets2]
+    ndocs = [sum(d.n_docs_remaining) for d in datasets]
+    print("n_docs_remaining from old loader:", ndocs)
+    ndocs = [sum(d.n_docs_remaining) for d in datasets2]
+    print("n_docs_remaining per new loader:", ndocs)
+
+    loaders2 = [iter(d) for d in datasets2]
+
+    print("Checking only", min(ndocs) * 3, "steps instead of full 50")
+    for j in range(min(ndocs) * 3):
+        for i in range(4):
+            out = next(loaders2[i])
+            assert (
+                out[0] not in ins
+            ), f"Step {j+1}, dataset {i+1}: chunk starting with {out[0]} has already appeared in the epoch"
+
+
+def test_scalable_sampler_reload_scale():
+    """
+    As test_reload_epoch, but in this case we scale from 2 workers to 4 (complete 1/3 epoch, reload, finish without duplication).
+    Because logical shards and sampling ratios won't be exact, take a few extra steps then check that epoch is complete.
+    """
+    datasets = [
+        Sampling_Dataset(
+            tmpdir.name,
+            Scalable_Shard_Dataset,
+            i,
+            2,
+            -1,
+            n_logical_shards=8,
+            trainsplit=1,
+            datasets=["dataset_1"],
+            weights=[1],
+            max_chunksize=40,
+        )
+        for i in range(2)
+    ]  # Length 300
+    loaders = [iter(d) for d in datasets]
+
+    ins = []
+    for _ in range(50):
+        out = next(loaders[0])
+        ins.append(out[0])
+    for _ in range(50):
+        out = next(loaders[1])
+        ins.append(out[0])
+
+    states = [d.state_dict() for d in datasets]
+
+    datasets2 = [
+        Sampling_Dataset(
+            tmpdir.name,
+            Scalable_Shard_Dataset,
+            i,
+            4,
+            -1,
+            n_logical_shards=8,
+            trainsplit=1,
+            datasets=["dataset_1"],
+            weights=[1],
+            max_chunksize=40,
+        )
+        for i in range(4)
+    ]  # Length 300
+    [d.load_state_dict(states) for d in datasets2]
+    loaders2 = [iter(d) for d in datasets2]
+
+    for i in range(4):
+        for _ in range(55):
+            out = next(loaders2[i])
+            ins.append(out[0])
+
+    for suf in [0, 40, 80]:
+        for i in range(100):
+            assert (
+                i * 100 + suf in ins
+            ), f"Expected value {i*100+suf} not found in output set {ins}"
+
+
+# BUFFER_DATASET TESTS
+
+
+class RandCounter:
+    # Spit out incremental counts of random length, uniformly sampled from 1 to 50
+    def __init__(self):
+        self.i = 0
+        self.rank = 0
+        self.worldsize = 1
+
+    def __iter__(self):
+        while True:
+            l = torch.randint(1, 50, [1]).item()
+            yield list(range(self.i, self.i + l))
+            self.i += l
+
+
+def test_buffer_format():
+    # Using the RandCounter, verify that streams are reformed into correct-length buffers,
+    # that final tokens match the predicted count, and that BOS/EOS add correctly
+
+    for _ in range(100):
+        # 100 trials of random length inputs
+        base = RandCounter()
+        dataset = Buffer_Dataset(base, 100, pack_hard=True)
+        loader = iter(dataset)
+        for _ in range(100):
+            out = next(loader)
+            assert (
+                len(out) == 100
+            ), f"Length of output {len(out)} does not match specified 100"
+        assert (
+            out[-1] == 100 * 100 - 1
+        ), f"Final token {out[-1]} does not match expected value {100*100-1}"
+
+    # As above, but now with EOS tokens
+    for _ in range(100):
+        base = RandCounter()
+        dataset = Buffer_Dataset(base, 100, pack_hard=True, eos_token=-1)
+        loader = iter(dataset)
+        for i in range(100):
+            out = next(loader)
+            assert (
+                len(out) == 100
+            ), f"Length of output {len(out)} does not match specified 100"
+            assert out[-1] == -1, f"Output {out} does not end in EOS"
+        assert (
+            out[-2] == 100 * 99 - 1
+        ), f"Penultimate token {out[-2]} does not match expected value {100*99-1}"
+
+    # As above, but now with BOS tokens
+    for _ in range(100):
+        base = RandCounter()
+        dataset = Buffer_Dataset(base, 100, pack_hard=True, bos_token=-1)
+        loader = iter(dataset)
+        for i in range(100):
+            out = next(loader)
+            assert (
+                len(out) == 100
+            ), f"Length of output {len(out)} does not match specified 100"
+            assert out[0] == -1, f"Output {out} does not begin with BOS"
+        assert (
+            out[-1] == 100 * 99 - 1
+        ), f"Final token {out[-1]} does not match expected value {100*99-1}"
+
+
+def test_buffer_delimiter_overlap():
+    """
+    Check that BOS adds correctly when absent, and refrains when present.
+    Because doc delimiter token is also -1, BOS will add in the first instance, which shunts the delimiter token
+    into the first slot in the next (and all subsequent) outputs. BOS should then refrain from adding.
+    """
+    dataset = basic_loader(max_chunksize=101)
+    dataset = Buffer_Dataset(dataset, 101, pack_hard=True, bos_token=-1)
+    loader = iter(dataset)
+    for _ in range(100):
+        out = next(loader)
+        assert (
+            len(out) == 101
+        ), f"Length of output {len(out)} does not match specified 101"
+        assert out[0] == -1, f"Output {out} does not begin with BOS"
+    assert (
+        out[-1] % 100 == 99
+    ), f"Final token {out[-1]} does not end in expected value 99"
+
+
+# PRELOAD_BUFFER_DATASET TESTS
+
+
+class SteadyCounter:
+    # Spit out incremental counts of constant length l
+    def __init__(self, l):
+        self.i = 0
+        self.rank = 0
+        self.worldsize = 1
+        self.l = l
+
+    def __iter__(self):
+        while True:
+            yield list(range(self.i, self.i + self.l))
+            self.i += self.l
+
+
+def test_preload_buffer_uniformity():
+    """
+    With underlying SteadyCounter and window size 200, take 1000 steps.
+    Ensure 95% of values between 0 and 100 are emitted.
+    """
+    dataset = Preload_Buffer_Dataset(SteadyCounter(1), 200)
+    loader = iter(dataset)
+    outs = []
+
+    for _ in range(1000):
+        x = next(loader)[0]
+        if x < 100:
+            outs.append(x)
+
+    assert len(outs) > 95, f"Only {len(outs)} values <100 detected"


### PR DESCRIPTION
Add tempfile-based dataloader unit tests from closed repo. 

Update StreamingDocDataset and PreloadBufferDataset for hygiene (no more repeated popping from long list, explicitly `del` expired readers)

Compress StreamingDocDataset's massive docset data structure into list of dataset/shard/(docid ranges)

Implement LCG-based random mapping as a pseudo-shuffle (since we're no longer materializing an ordered list of docids)