### PR TITLE
Improve the speed of fms-hf converter

### DIFF
--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -98,7 +98,9 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
 def main(model_variant, compiled, load_path, save_path, tokenizer_name_or_path):
     print("Initializing model...")
     llama_config = get_model_config(model_variant)
-    model = LLaMA(llama_config, orig_init=True)
+    with torch.device("meta"):
+        model = LLaMA(llama_config)
+    model.to_empty(device="cpu")
 
     print(f"Reading state dict from {load_path}")
     if not compiled:


### PR DESCRIPTION
In fms-hf converter, we don't care about the initial parameter init as it will be overwritten by the ckpt anyway.  In such cases, "meta device -> to_empty" is faster than "init a model".  i.e. we can replace
```python
model = Model()
```
with
```python
with torch.device("meta"):
    model = Model()
model.to_empty()
```
to boost the performance.