### PR TITLE
populate more configs and metrics to Tracker

### DIFF
--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -114,11 +114,14 @@ def train(
                 current_loss = train_loss.item()
                 current_lr = scheduler.get_last_lr()[0]
                 current_gnorm = g_norm.item()
-                current_elapsed_time = (time.time() - start) / cfg.report_interval
+                current_step_time = (time.time() - start) / cfg.report_interval
+                overall_step_time = elapsed_time / (batch_idx - start_step)
                 current_throughput = int(
-                    cfg.batch_size * cfg.seq_length / current_elapsed_time
+                    cfg.batch_size * cfg.seq_length / current_step_time
                 )
-                overall_throughput = int(new_tokens_seen / world_size / elapsed_time)
+                overall_throughput = int(
+                    cfg.batch_size * cfg.seq_length / overall_step_time
+                )
                 reserved_mem = torch.cuda.max_memory_reserved(
                     device=torch.cuda.current_device()
                 )
@@ -127,17 +130,14 @@ def train(
                 )
 
                 print("step:", batch_idx)
-                print("tokens seen:", total_tokens_seen)
                 print("loss:", current_loss)
-                print("gradient norm:", current_gnorm)
-                print(
-                    f"speed for these {cfg.report_interval} steps:",
-                    current_elapsed_time,
-                )
-                print("overall speed:", elapsed_time / (batch_idx - start_step))
                 print("LR:", current_lr)
+                print("tokens seen:", total_tokens_seen)
+                print("gradient norm:", current_gnorm)
                 print("reserved memory:", reserved_mem)
                 print("allocated memory:", allocated_mem)
+                print("current step time:", current_step_time)
+                print("overall step time:", overall_step_time)
                 print("current token per gpu per sec:", current_throughput)
                 print("overall token per gpu per sec:", overall_throughput)
                 print(

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import asdict
 from functools import partial
 
 
@@ -36,11 +37,6 @@ def train(
         tracker_dir = cfg.tracker_dir
         project_name = cfg.tracker_project_name
         run_id = cfg.tracker_run_id
-        hparams = {
-            "learning_rate": cfg.learning_rate,
-            "num_steps": cfg.num_steps,
-            "batch_size": cfg.batch_size,
-        }
 
         if cfg.tracker == "wandb":
             try:
@@ -60,7 +56,7 @@ def train(
                     raise ValueError(
                         "wandb failed to init, did you pass your wandb api key via WANDB_API_KEY?"
                     )
-                wandb.config = hparams
+                wandb.config = asdict(cfg)
 
         if cfg.tracker == "aim":
             try:
@@ -74,7 +70,7 @@ def train(
                     repo=tracker_dir,
                     run_hash=run_id,
                 )
-                run["hparams"] = hparams
+                run["hparams"] = asdict(cfg)
 
     model.train()
     ddp_stats = torch.zeros(3).to(local_rank)

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -115,7 +115,9 @@ def train(
                 current_lr = scheduler.get_last_lr()[0]
                 current_gnorm = g_norm.item()
                 current_elapsed_time = (time.time() - start) / cfg.report_interval
-                current_throughput = int(cfg.batch_size * cfg.seq_length / current_elapsed_time)
+                current_throughput = int(
+                    cfg.batch_size * cfg.seq_length / current_elapsed_time
+                )
                 overall_throughput = int(new_tokens_seen / world_size / elapsed_time)
                 reserved_mem = torch.cuda.max_memory_reserved(
                     device=torch.cuda.current_device()
@@ -138,7 +140,10 @@ def train(
                 print("allocated memory:", allocated_mem)
                 print("current token per gpu per sec:", current_throughput)
                 print("overall token per gpu per sec:", overall_throughput)
-                print("overall token per day:", int(new_tokens_seen / elapsed_time * 3600 * 24))
+                print(
+                    "overall token per day:",
+                    int(new_tokens_seen / elapsed_time * 3600 * 24),
+                )
                 if cfg.tracker:
                     vals_to_track = {
                         "learning rate": current_lr,


### PR DESCRIPTION
We populate more info to tracker:
1. Instead of only saving a few key hyper-parameters in tracker's meta data, we save the full cfg.
2. Instead of saving only one throughput, we separate "current throughput" vs. "overall throughput".