### PR TITLE
Enable asynchronous dataloading

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -13,6 +13,7 @@ class train_config:
     use_dummy_dataset: bool = False
     data_path: str = "/lustre/data"
     seq_length: int = 4096
+    vocab_size: int = 32000
     sep_token: int = 1
     datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange,lang=en/dataset=PG19"
     weights: str = "7700,500,550,28,17,22,25,8,100,500,175,250,100,25"

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -6,44 +6,44 @@ from typing import Optional, Union
 class train_config:
     # model
     model_variant: str = "7b"
-    ckpt_load_path: str = "/lustre/pretrain/ckpt"
-    ckpt_save_path: str = "/lustre/pretrain/ckpt"
+    ckpt_load_path: str = "/fsx/output/ckpt"
+    ckpt_save_path: str = "/fsx/output/ckpt"
 
     # dataset and dataloader
     use_dummy_dataset: bool = False
-    data_path: str = "/lustre/data"
+    data_path: str = "/fsx/data"
+    datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange"
+    weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"
     seq_length: int = 4096
     vocab_size: int = 32000
     sep_token: int = 1
-    datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange,lang=en/dataset=PG19"
-    weights: str = "7700,500,550,28,17,22,25,8,100,500,175,250,100,25"
-    logical_shards: int = 768
+    logical_shards: int = 1024
 
     # fsdp policies
-    mixed_precision: bool = True
+    sharding_strategy: str = "hsdp"
     fsdp_activation_checkpointing: bool = False
     selective_checkpointing: Union[float, str] = 1  # percentage of blocks to apply ac
-    sharding_strategy: str = "hsdp"
+    mixed_precision: bool = True
     low_cpu_fsdp: bool = False
 
     # training spec
-    seed: int = 2023
     batch_size: int = 2
-    num_steps: int = 2000000
+    num_steps: int = 1000000
     learning_rate: float = 3e-4
     grad_clip_thresh: float = 1.0
+    seed: int = 2023
 
     # profiling
     use_profiler: bool = False
     profiler_rank0_only: bool = True
 
     # logging
-    report_interval: int = 200
-    checkpoint_interval: int = 20000
+    report_interval: int = 100
+    checkpoint_interval: int = 10000
     tracker: Optional[str] = None  # None, "wandb", "aim"
-    tracker_dir: str = "/lustre/lchu/fms-fsdp"
+    tracker_dir: str = "/fsx/aim_logs/llama"
     tracker_project_name: str = "llama"  # project name for a group of runs
     tracker_run_id: Optional[str] = None  # run id, for job resume purpose
 
     # compile
-    use_torch_compile: bool = False
+    use_torch_compile: bool = True

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -260,7 +260,7 @@ class Checkpointer:
         with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
             model_state = model.state_dict()
             optim_state = FSDP.sharded_optim_state_dict(model, optimizer)
-        dataloader_state = dataloader.dataset
+        dataloader_state = None if dataloader is None else dataloader.dataset
 
         save_name = os.path.join(self.ckp_path, "step_" + str(step) + "_ckp")
         state_dict = {"model_state": model_state, "optimizer_state": optim_state}

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -55,6 +55,26 @@ def get_model_config(model_variant):
             nheads=16,
             nlayers=24,
         )
+    elif model_variant == "8b":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=4096,
+            nheads=32,
+            kvheads=8,
+            nlayers=32,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=8192,
+        )
+    elif model_variant == "8b_4k":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=4096,
+            nheads=32,
+            kvheads=8,
+            nlayers=32,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=4096,
+        )
     else:
         raise ValueError(f"model variant {model_variant} not supported.")
 

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -103,7 +103,7 @@ def get_model_config(model_variant):
             kvheads=8,
             nlayers=80,
             hidden_grow_factor=3.5,
-            max_expected_seq_len=4096,
+            max_expected_seq_len=8192,
         )
     elif model_variant == "llama3_70b_4k":
         llama_config = LLaMAConfig(
@@ -113,7 +113,7 @@ def get_model_config(model_variant):
             kvheads=8,
             nlayers=80,
             hidden_grow_factor=3.5,
-            max_expected_seq_len=8192,
+            max_expected_seq_len=4096,
         )
     else:
         raise ValueError(f"model variant {model_variant} not supported.")

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -55,7 +55,7 @@ def get_model_config(model_variant):
             nheads=16,
             nlayers=24,
         )
-    elif model_variant == "8b":
+    elif model_variant == "llama3_8b":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=4096,
@@ -65,13 +65,33 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.5,
             max_expected_seq_len=8192,
         )
-    elif model_variant == "8b_4k":
+    elif model_variant == "llama3_8b_4k":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=4096,
             nheads=32,
             kvheads=8,
             nlayers=32,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=4096,
+        )
+    elif model_variant == "llama3_1.8b":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=2048,
+            nheads=16,
+            kvheads=8,
+            nlayers=24,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=8192,
+        )
+    elif model_variant == "llama3_1.8b_4k":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=2048,
+            nheads=16,
+            kvheads=8,
+            nlayers=24,
             hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -95,6 +95,26 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
+    elif model_variant == "llama3_70b":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=8192,
+            nheads=64,
+            kvheads=8,
+            nlayers=80,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=4096,
+        )
+    elif model_variant == "llama3_70b_4k":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=8192,
+            nheads=64,
+            kvheads=8,
+            nlayers=80,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=8192,
+        )
     else:
         raise ValueError(f"model variant {model_variant} not supported.")
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -1,5 +1,4 @@
 import torch
-from torch.utils.data.distributed import DistributedSampler
 
 from fms_fsdp.utils.dataset_utils import (
     Buffer_Dataset,
@@ -7,7 +6,6 @@ from fms_fsdp.utils.dataset_utils import (
     Preprocess_Dataset,
     Sampling_Dataset,
     Scalable_Shard_Dataset,
-    Streaming_Doc_Dataset,
 )
 
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -2,6 +2,7 @@ import torch
 
 from fms_fsdp.utils.dataset_utils import (
     Buffer_Dataset,
+    Checkpoint_Dataset,
     Preload_Buffer_Dataset,
     Preprocess_Dataset,
     Sampling_Dataset,
@@ -90,8 +91,11 @@ def get_data_loader(cfg, rank, world_size):
     data = Preload_Buffer_Dataset(data, 10000)
     # Split line into input and target for the CLM task.
     data = Preprocess_Dataset(data, causal_lm)
-
-    return torch.utils.data.DataLoader(data, num_workers=0, batch_size=cfg.batch_size)
+    # Enable auto-saving
+    data = Checkpoint_Dataset(
+        data, cfg.ckpt_load_path, cfg.checkpoint_interval, cfg.ckpt_save_path
+    )
+    return torch.utils.data.DataLoader(data, num_workers=1, batch_size=cfg.batch_size)
 
 
 def parse_data_args(datas, weights):

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -19,8 +19,6 @@ def get_dummy_loader(cfg, rank, world_size):
         # Spit out incremental counts of constant length l, modulo vocab size v
         def __init__(self, l, v):
             self.i = 0
-            self.rank = 0
-            self.worldsize = 1
             self.l = l
             self.v = v
 
@@ -33,8 +31,8 @@ def get_dummy_loader(cfg, rank, world_size):
                 self.i += self.l
 
     data = SteadyCounter(
-        cfg.seq_length, 32000
-    )  # hardcode 32k vocab size since vocab size isn't available in the cfg
+        cfg.seq_length, cfg.vocab_size
+    )
     return torch.utils.data.DataLoader(data, batch_size=cfg.batch_size)
 
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -30,9 +30,7 @@ def get_dummy_loader(cfg, rank, world_size):
                 yield out, out
                 self.i += self.l
 
-    data = SteadyCounter(
-        cfg.seq_length, cfg.vocab_size
-    )
+    data = SteadyCounter(cfg.seq_length, cfg.vocab_size)
     return torch.utils.data.DataLoader(data, batch_size=cfg.batch_size)
 
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -93,7 +93,11 @@ def get_data_loader(cfg, rank, world_size):
     data = Preprocess_Dataset(data, causal_lm)
     # Enable auto-saving
     data = Checkpoint_Dataset(
-        data, cfg.ckpt_load_path, cfg.checkpoint_interval, cfg.ckpt_save_path
+        data,
+        cfg.ckpt_load_path,
+        cfg.checkpoint_interval,
+        cfg.batch_size,
+        cfg.ckpt_save_path,
     )
     return torch.utils.data.DataLoader(data, num_workers=1, batch_size=cfg.batch_size)
 

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -264,19 +264,22 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
     ----
     dataset : _Stateful_Dataset
         Fully instantiated dataset
-    path : str
-        Absolute path to save/load directory. If a checkpoint exists, load it during construction.
-        Saves new checkpoints via step count.
+    load_path : str
+        Absolute path to checkpoint load directory. If a checkpoint exists, loads it.
     interval : int
         Saves a new checkpoint every interval.
+    save_path : optional[str]
+        Absolute path to checkpoint save directory. Defaults to load_path.
     """
 
-    def __init__(self, dataset: _Stateful_Dataset, path: str, interval: int):
+    def __init__(self, dataset: _Stateful_Dataset, load_path: str, interval: int, save_path: Optional[str] = ""):
         super().__init__(dataset)
         self.interval = interval
-        self.path = path
+        if len(save_path) == 0:
+            save_path = load_path
+        self.path = save_path
         self.step = 0
-        self.load_from_path(path)
+        self.load_from_path(load_path)
 
     def __iter__(self):
         dataset = iter(self.dataset)

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -286,8 +286,11 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
         super().__init__(dataset)
         self.interval = interval
         self.spb = steps_per_batch
+        load_path = os.path.join(load_path, "checkpoints")
         if len(save_path) == 0:
             save_path = load_path
+        else:
+            save_path = os.path.join(save_path, "checkpoints")
         self.path = save_path
         self.step = 0
         self.ministep = 0

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -272,7 +272,13 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
         Absolute path to checkpoint save directory. Defaults to load_path.
     """
 
-    def __init__(self, dataset: _Stateful_Dataset, load_path: str, interval: int, save_path: Optional[str] = ""):
+    def __init__(
+        self,
+        dataset: _Stateful_Dataset,
+        load_path: str,
+        interval: int,
+        save_path: Optional[str] = "",
+    ):
         super().__init__(dataset)
         self.interval = interval
         if len(save_path) == 0:
@@ -298,7 +304,7 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
         if len(os.listdir(path)) == 0:
             return
         # Grab latest item in path
-        latest = get_latest(path)
+        latest = os.path.join(path, get_latest(path))
         # If item is not a folder, do nothing
         if os.path.isfile(latest):
             return
@@ -306,6 +312,8 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
         self.step = int(latest.split("_")[-2])
         # Proceed
         self.dataset.load_from_path(latest)
+        if self.rank == 0:
+            print(f"Dataset checkpoint loaded from {latest}")
 
 
 class Preload_Buffer_Dataset(_Wrapper_Dataset):

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -280,8 +280,8 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
         dataset: _Stateful_Dataset,
         load_path: str,
         interval: int,
-        steps_per_batch: Optional[int] = 1,
-        save_path: Optional[str] = "",
+        steps_per_batch: int = 1,
+        save_path: str = "",
     ):
         super().__init__(dataset)
         self.interval = interval

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -170,7 +170,7 @@ def train(
                 batch_idx,
                 model,
                 optimizer,
-                train_loader,
+                None,
                 tokens_seen=tokens_seen + new_tokens_seen,
             )
 

--- a/main_training.py
+++ b/main_training.py
@@ -118,10 +118,10 @@ def main(**kwargs):
     checkpointer = Checkpointer(
         cfg.ckpt_save_path, 1000, cfg.sharding_strategy, rank, local_rank
     )
-    model, optimizer, train_loader, start_step, tokens_seen = checkpointer.load(
+    model, optimizer, _, start_step, tokens_seen = checkpointer.load(
         model,
         optimizer,
-        train_loader,
+        None,
         path=os.path.join(cfg.ckpt_load_path, "checkpoints/"),
     )
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -980,13 +980,14 @@ def test_checkpoint_reload_match():
         )
         for i in range(3)
     ]
+    datasets = [Buffer_Dataset(d, 73, pack_hard=True, bos_token=-1) for d in datasets]
     datasets = [
-        Checkpoint_Dataset(x, os.path.join(tmpdir.name, "ckp_test"), 100)
+        Checkpoint_Dataset(x, os.path.join(tmpdir.name, "ckp_test"), 100, 2)
         for x in datasets
     ]
     loaders = [
         torch.utils.data.DataLoader(
-            x, num_workers=1, batch_size=1, prefetch_factor=1, persistent_workers=True
+            x, num_workers=1, batch_size=2, prefetch_factor=1, persistent_workers=True
         )
         for x in datasets
     ]
@@ -1016,8 +1017,9 @@ def test_checkpoint_reload_match():
         )
         for i in range(3)
     ]
+    datasets2 = [Buffer_Dataset(d, 73, pack_hard=True, bos_token=-1) for d in datasets2]
     datasets2 = [
-        Checkpoint_Dataset(x, os.path.join(tmpdir.name, "ckp_test"), 1000)
+        Checkpoint_Dataset(x, os.path.join(tmpdir.name, "ckp_test"), 1000, 2)
         for x in datasets2
     ]
 
@@ -1028,15 +1030,15 @@ def test_checkpoint_reload_match():
     # Continue iterating, verify matching behavior
     loaders2 = [
         torch.utils.data.DataLoader(
-            x, num_workers=1, batch_size=1, prefetch_factor=1, persistent_workers=True
+            x, num_workers=1, batch_size=2, prefetch_factor=1, persistent_workers=True
         )
         for x in datasets2
     ]
     loaders2 = [iter(x) for x in loaders2]
     for _ in range(300):
         for loader, loader2 in zip(loaders, loaders2):
-            out = next(loader2)
-            targ = next(loader)
+            out = sum(next(loader2))
+            targ = sum(next(loader))
             assert len(out) == len(
                 targ
             ), f"Expected same output lengths, got {len(out)}, {len(targ)}"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -997,9 +997,11 @@ def test_checkpoint_reload_match():
             next(loader)
 
     # Assert checkpoint exists and is properly formatted
-    ckps = os.listdir(os.path.join(tmpdir.name, "ckp_test"))
+    ckps = os.listdir(os.path.join(tmpdir.name, "ckp_test", "checkpoints"))
     assert len(ckps) == 1, f"Expected only one checkpoint (found {len(ckps)})"
-    ckp_shards = os.listdir(os.path.join(tmpdir.name, "ckp_test", ckps[0]))
+    ckp_shards = os.listdir(
+        os.path.join(tmpdir.name, "ckp_test", "checkpoints", ckps[0])
+    )
     assert (
         len(ckp_shards) == 3
     ), f"Expected three checkpoint shards (found {len(ckp_shards)})"


### PR DESCRIPTION
Current dataloader still causes gradual asymptotic slowdowns - likely because we have n_workers fixed to 0 in the dataloader. This forces the main process to also handle dataloading in a synchronous manner, allowing the two tasks to interfere. The reason we fix to 0 is because the main process performs checkpointing, and if dataloading is occurring on a separate worker process, the master cannot access the relevant state information from the worker. 

This PR adds support for n_workers set to 1, allowing the worker to checkpoint itself at set intervals, separate from the model/optimizer checkpointing occurring in the master process. This is accomplished via a new `Checkpoint_Dataset` wrapper that performs checkpointing on set intervals. Training script and other peripherals are updated to set n_workers to 1.

Note that while the `Checkpoint_Dataset` class has been correctness-checked via the new unit test, the main training script has not yet been tested with these changes. We do not yet know if this PR will fix the throughput issue, and this should not be merged until we do.