### PR TITLE
add llama3 8b config

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -13,6 +13,7 @@ class train_config:
     use_dummy_dataset: bool = False
     data_path: str = "/lustre/data"
     seq_length: int = 4096
+    vocab_size: int = 32000
     sep_token: int = 1
     datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange,lang=en/dataset=PG19"
     weights: str = "7700,500,550,28,17,22,25,8,100,500,175,250,100,25"

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -55,6 +55,26 @@ def get_model_config(model_variant):
             nheads=16,
             nlayers=24,
         )
+    elif model_variant == "8b":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=4096,
+            nheads=32,
+            kvheads=8,
+            nlayers=32,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=8192,
+        )
+    elif model_variant == "8b_4k":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=4096,
+            nheads=32,
+            kvheads=8,
+            nlayers=32,
+            hidden_grow_factor=3.5,
+            max_expected_seq_len=4096,
+        )
     else:
         raise ValueError(f"model variant {model_variant} not supported.")
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -31,9 +31,7 @@ def get_dummy_loader(cfg, rank, world_size):
                 yield out, out
                 self.i += self.l
 
-    data = SteadyCounter(
-        cfg.seq_length, cfg.vocab_size
-    )
+    data = SteadyCounter(cfg.seq_length, cfg.vocab_size)
     return torch.utils.data.DataLoader(data, batch_size=cfg.batch_size)
 
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -20,8 +20,6 @@ def get_dummy_loader(cfg, rank, world_size):
         # Spit out incremental counts of constant length l, modulo vocab size v
         def __init__(self, l, v):
             self.i = 0
-            self.rank = 0
-            self.worldsize = 1
             self.l = l
             self.v = v
 
@@ -34,8 +32,8 @@ def get_dummy_loader(cfg, rank, world_size):
                 self.i += self.l
 
     data = SteadyCounter(
-        cfg.seq_length, 32000
-    )  # hardcode 32k vocab size since vocab size isn't available in the cfg
+        cfg.seq_length, cfg.vocab_size
+    )
     return torch.utils.data.DataLoader(data, batch_size=cfg.batch_size)
 
 


### PR DESCRIPTION
Add llama3 8b config.

we also expose vocab_size to make our dummy dataloader configurable with llama3 so we can overwrite default 32k to 128k.