### PR TITLE
Add proper BOS support to dataloader

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -17,7 +17,7 @@ class train_config:
     seq_length: int = 4096
     vocab_size: int = 32000
     bos_token: Optional[int] = None
-    eos_token: Optional[int] = None
+    eos_token: int = 0
     logical_shards: int = 1024
 
     # fsdp policies

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -16,7 +16,8 @@ class train_config:
     weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"
     seq_length: int = 4096
     vocab_size: int = 32000
-    sep_token: int = 1
+    bos_token: Optional[int] = None
+    eos_token: Optional[int] = None
     logical_shards: int = 1024
 
     # fsdp policies

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -81,7 +81,6 @@ def get_data_loader(cfg, rank, world_size):
     data = Buffer_Dataset(
         data,
         cfg.seq_length + 1,
-        drop_final_token=cfg.sep_token,
         pack_hard=True,
     )
     # Shuffle outputs in length 10k buffer. Consecutive lines appear 10k steps apart on average.

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -69,7 +69,8 @@ def get_data_loader(cfg, rank, world_size):
         Scalable_Shard_Dataset,
         rank,
         world_size,
-        cfg.sep_token,
+        cfg.eos_token,
+        bos_token=cfg.bos_token,
         min_length=3,
         datasets=datasets,
         weights=weights,
@@ -81,6 +82,7 @@ def get_data_loader(cfg, rank, world_size):
     data = Buffer_Dataset(
         data,
         cfg.seq_length + 1,
+        bos_token=cfg.bos_token,
         pack_hard=True,
     )
     # Shuffle outputs in length 10k buffer. Consecutive lines appear 10k steps apart on average.

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -328,8 +328,8 @@ class Buffer_Dataset(_Wrapper_Dataset):
     Wrapper for a _Stateful_Dataset that takes in sequences of varying lengths, and packs/pads them
     into sequences of desired length. Input sequences are packed greedily until the buffer would
     otherwise overrun, then remaining values are filled depending on initialization flags.
-    Also injects BOS/EOS into the output sequence if desired, and if BOS/EOS tokens are not
-    already in those positions. Implements rescaling by simply dropping (buffer) state.
+    Also injects BOS/EOS into the packed output sequence if desired, and if BOS/EOS tokens are
+    not already in those positions. Implements rescaling by simply dropping (buffer) state.
     ...
     Args
     ----
@@ -460,7 +460,10 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
     worldsize : int
         Total number of workers
     delimiter_token : Any
-        Token used to indicate sequence/document breaks. Type should match data type.
+        Token used to indicate sequence/document breaks. Type should match data type. Required for
+        downstream sampling logic (can be removed later via Buffer_Dataset).
+    bos_token : Any | None
+        Optional token used to indicate sequence/document start. Type should match data type.
     datasets : list[str] | None
         A list of subdatasets to draw from. If None, draws from all subfolders.
     weights : list[int] | None
@@ -483,6 +486,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         rank: int,
         worldsize: int,
         delimiter_token: Any,
+        bos_token: Optional[Any] = None,
         datasets: Optional[List[str]] = None,
         weights: Optional[List[int]] = None,
         seed: int = 42,
@@ -497,7 +501,8 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         self.min_length = min_length
         assert max_chunksize > 0, f"Max chunksize must be a nonzero positive integer"
         self.chunksize = max_chunksize
-        self.delimiter = delimiter_token
+        self.eos = delimiter_token
+        self.bos = bos_token
         self.verbose = verbose
         self.docset: List[
             Any
@@ -658,12 +663,19 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         """
         start_index = j * self.chunksize
         n_pull = self.chunksize
+        if self.bos is not None:
+            if j == 0:
+                n_pull -= 1
+            else:
+                start_index -= 1
         chunk = doc.slice(start_index, n_pull).to_pylist()
-        self.dataset_tokens_seen[dataset] += len(chunk)
+        if self.bos is not None and j == 0:
+            chunk = [self.bos] + chunk
         if j == n_chunks - 1:
             chunk = chunk + [
-                self.delimiter
+                self.eos
             ]  # Add delimiter token to signify end of document (used upstream)
+        self.dataset_tokens_seen[dataset] += len(chunk)
         return chunk
 
     def _random_map_docid(self, size):
@@ -706,9 +718,10 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 doclcg = self._random_map_docid(docrange)
                 docid = doclcg + mindoc
                 doc = reader.get_batch(docid)["tokens"]
-                if len(doc) >= self.min_length:
+                doclen = len(doc) + 1 if self.bos is None else len(doc) + 2
+                if doclen >= self.min_length:
                     n_chunks = math.ceil(
-                        (len(doc) + 1) / self.chunksize
+                        doclen / self.chunksize
                     )  # add 1 for delimiter token
                     for j in range(n_chunks):
                         if i == 0 and j < residual_chunks:
@@ -759,7 +772,7 @@ class Sampling_Dataset(_Stateful_Dataset):
     the number of tokens emitted by each. Whichever loader is furthest from its target will be
     the next to pass a document.
 
-    All args except for dataset and weights are pass-through args for the component
+    All args except for dataset, weights and delimiter are pass-through args for the component
     _Stateful_Datasets and are documented in the appropriate classes.
     ...
     Args
@@ -769,6 +782,8 @@ class Sampling_Dataset(_Stateful_Dataset):
     weights : list(float) | None
         Weights describing what percent of emitted tokens should come from each subdataset.
         Need not sum to 1. If None, tokens are drawn evenly.
+    delimiter_token : Any
+        Token used to indicate sequence/document breaks. Type should match data type.
     ...
         Pass-through args, see Streaming_Doc_Dataset or Scalable_Shard_Dataset
     """

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -530,27 +530,26 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
     Pyarrow shard files are expected to hold multiple recordBatches, where each recordBatch has a "tokens"
     field consisting of a single token list. (i.e. each document is a single sequence under a "token" field,
     and the file is a list of such sequences)
-    Relies on a compiled metadata file to fetch shardfile lengths, assumes file already exists in the parent directory,
-    and is in proper csv format (first row "dataset/filename,documents,tokens", subsequent rows these values).
+    Relies on a compiled metadata file to fetch shardfile lengths, assumes file already exists and is in
+    proper csv format (first row "dataset/filename,documents,tokens", subsequent rows these values).
 
-    For a single dataset directory, splits shard files into x=worldsize fragments and grabs a 1/n contiguous
-    span of shard fragments (contiguous to limit file reads from cloud/disk).
+    For each subdataset, splits shard files into x=worldsize fragments and grabs a 1/n contiguous span
+    of shard fragments (contiguous to limit file reads from cloud/disk).
     Logs the number of documents owned from each shardfile, and relies on ZCG random bijection to
     map contiguous range of indices to shuffled, noncontiguous set of documents from each shard file.
-    Shuffles the file list deterministically to hop from file to file.
+    Compiles oversamples across subdatasets, and shuffles the list deterministically to hop from file to file.
 
     At runtime, iterates through documents in each shuffled shard file, pulling each shard on demand.
-    Shards are thus pulled no more than once per epoch.
+    Shards are thus pulled no more than [oversample] times.
     Returns documents in chunks up to size max_chunksize, and handles delimiter token placement between documents.
 
-    Streaming_Doc_Dataset grabs files from a flat directory representing a single dataset.
-    For percentage-based sampling of multiple subdatasets, see Sampling_Dataset.
+    Streaming_Doc_Dataset uses integer weights to implement dataset weighting via oversampling per-epoch.
+    For non-epoch, percentage-based sampling, see Sampling_Dataset, which overrides this logic.
     ...
     Args
     ----
     datapath : str
-        Absolute path to the dataset directory. Expects directory containing pyarrow shardfiles.
-        Parent directory should contain 'meta' folder with metadata csv file inside.
+        Absolute path to the dataset directory. Expects subfolders containing pyarrow shardfiles.
     rank : int
         Current worker index
     worldsize : int
@@ -560,6 +559,10 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         sampling logic (can be removed later via PreProcess_Dataset or Buffer_Dataset's drop_final_token flag).
     bos_token : Any | None
         Optional token used to indicate sequence/document start. Type should match data type.
+    datasets : list[str] | None
+        A list of subdatasets to draw from. If None, draws from all subfolders.
+    weights : list[int] | None
+        A list of oversample rates for each subdataset. If None, draws from all subdatasets equally.
     seed : int
         The random seed for deterministic shuffling/sharding
     min_length : int
@@ -579,6 +582,8 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         worldsize: int,
         delimiter_token: Any,
         bos_token: Optional[Any] = None,
+        datasets: Optional[List[str]] = None,
+        weights: Optional[List[int]] = None,
         seed: int = 42,
         min_length: int = 1,
         max_chunksize: int = 1024,
@@ -596,79 +601,103 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         self.verbose = verbose
         self.docset: List[
             Any
-        ] = []  # map of doc indices to (shardid, min docid, max docid)
+        ] = []  # map of doc indices to (dataset, shardid, min docid, max docid)
+        self.datasets = (
+            datasets
+            if datasets is not None
+            else [
+                f
+                for f in os.listdir(datapath)
+                if not os.path.isfile(os.path.join(datapath, f)) and "meta" not in f
+            ]
+        )
+        assert len(self.datasets) > 0, "You must specify at least one dataset"
+        self.docs_per_dataset = {}
+        self.docs_per_shard = {}
 
+        if weights is not None:
+            assert len(weights) == len(
+                self.datasets
+            ), f"Number of oversample weights {len(weights)} must match number of datasets {len(self.datasets)}"
+            for w in weights:
+                assert w > 0, f"Oversample rate {w} must be a positive integer"
+        self.weights = (
+            {self.datasets[i]: weights[i] for i in range(len(self.datasets))}
+            if weights is not None
+            else {d: 1 for d in self.datasets}
+        )
         # Guaranteed inconsistent shuffling across workers
         random.seed(self.seed + rank)
 
         # Gather per-file document counts from metadata count file(s)
         countfiles = [
             x
-            for x in os.listdir(os.path.join(os.path.dirname(datapath), "meta"))
+            for x in os.listdir(os.path.join(datapath, "meta"))
             if "counts" in x and "csv" in x
         ]
         assert len(countfiles) == 1
         doc_counts = {}
-        pathsplit = [datapath, ""]
-        while len(pathsplit[1]) == 0:
-            pathsplit = os.path.split(pathsplit[0])
-        pardir, dataset = pathsplit
-        self.dataset = dataset
-        with open(os.path.join(pardir, "meta", countfiles[0]), "r") as csvfile:
+        with open(os.path.join(datapath, "meta", countfiles[0]), "r") as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 fullpath = row["dataset/filename"]
-                prefix = fullpath.find("/" + dataset) + 1
+                prefix = max([fullpath.find("/" + d) for d in self.datasets]) + 1
                 if prefix > 0:
                     key = fullpath[prefix:]
                     doc_counts[key] = int(row["documents"])
 
-        # Assemble document set owned by this worker:
-        # listdir, assemble shardfraglist (ind -> shard, frag)
-        shards = [
-            shard
-            for shard in os.listdir(datapath)
-            if os.path.isfile(os.path.join(datapath, shard))
-            and "arrow" in os.path.join(datapath, shard)
-        ]
-        shards.sort()  # Ensure consistent sharding across machines
-        start_frag = (rank * worldsize * len(shards)) // worldsize
-        end_frag = ((rank + 1) * worldsize * len(shards)) // worldsize
-        shardfrags = [
-            (shards[i // worldsize], i % worldsize) for i in range(start_frag, end_frag)
-        ]
+        # Assemble document sets owned by this worker
+        for dataset in self.datasets:
+            # Listdir, assemble shardfraglist (ind -> shard, frag)
+            shards = [
+                shard
+                for shard in os.listdir(os.path.join(datapath, dataset))
+                if os.path.isfile(os.path.join(datapath, dataset, shard))
+                and "arrow" in os.path.join(datapath, dataset, shard)
+            ]
+            shards.sort()  # Ensure consistent sharding across machines
+            start_frag = (rank * worldsize * len(shards)) // worldsize
+            end_frag = ((rank + 1) * worldsize * len(shards)) // worldsize
+            shardfrags = [
+                (shards[i // worldsize], i % worldsize)
+                for i in range(start_frag, end_frag)
+            ]
 
-        # Read shardfrags, assemble doc list for each file shard (aggregating over fragments):
-        ndocs = -1
-        docset = {}  # shardid -> (min docid, max docid)
-        for i, (shard, frag) in enumerate(shardfrags):
-            ndocs = doc_counts[os.path.join(dataset, shard)]
-            self.docs_per_shard[shard] = ndocs
-            doc_start = (ndocs * frag) // worldsize
-            doc_end = (ndocs * frag + ndocs) // worldsize - 1  # Inclusive upper bound
-            if shard not in docset:
-                docset[shard] = [doc_start, doc_end]
-            min_d, max_d = docset[shard]
-            if doc_start < min_d:
-                docset[shard][0] = doc_start
-            if doc_end > max_d:
-                docset[shard][1] = doc_end
+            # Read shardfrags, assemble doc list for each file shard (aggregating over fragments):
+            ndocs = -1
+            docset = {}  # shardid -> (min docid, max docid)
+            for i, (shard, frag) in enumerate(shardfrags):
+                ndocs = doc_counts[os.path.join(dataset, shard)]
+                self.docs_per_shard[(dataset, shard)] = ndocs
+                doc_start = (ndocs * frag) // worldsize
+                doc_end = (
+                    ndocs * frag + ndocs
+                ) // worldsize - 1  # Inclusive upper bound
+                if shard not in docset:
+                    docset[shard] = [doc_start, doc_end]
+                min_d, max_d = docset[shard]
+                if doc_start < min_d:
+                    docset[shard][0] = doc_start
+                if doc_end > max_d:
+                    docset[shard][1] = doc_end
 
-        # Add all of this dataset's shard entries to self.docset
-        doccount = 0
-        for shardid in docset:
-            min_d = docset[shardid][0]
-            max_d = docset[shardid][1]
-            self.docset.append((shardid, min_d, max_d))
-            doccount += max_d - min_d + 1
-        self._len = doccount
+            # Add all of this dataset's shard entries to self.docset, with oversampling
+            doccount = 0
+            for shardid in docset:
+                for _ in range(self.weights[dataset]):
+                    min_d = docset[shardid][0]
+                    max_d = docset[shardid][1]
+                    self.docset.append((dataset, shardid, min_d, max_d))
+                    doccount += max_d - min_d + 1
+            self.docs_per_dataset[dataset] = doccount
+            self._len = sum(self.docs_per_dataset.values())
 
-        if verbose:
-            logging.info(
-                f"    Worker {rank} ingested {len(shardfrags)} shard fragments from {dataset}"
-            )
+            if verbose:
+                logging.info(
+                    f"    Worker {rank} ingested {len(shardfrags)} shard fragments from {dataset}"
+                )
 
-        # Shuffle shard files
+        # Shuffle shardsets across datasets, and flatten
         if shuffle:
             random.shuffle(self.docset)
 
@@ -677,20 +706,21 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
 
         # Stats
         self.epochs_seen = -1
-        self.tokens_seen = 0
-        self.docs_seen = 0
-        self.percent_seen = 0
+        self.dataset_tokens_seen = {d: 0 for d in self.datasets}
+        self.dataset_docs_seen = {d: 0 for d in self.datasets}
+        self.dataset_percent_seen = {d: 0 for d in self.datasets}
         self.lcg_state = seed + rank
+        # self.docs_seen: Dict[Any, int] = {}  # (dataset, shard, i) -> # times seen
 
         self.state_params = [
-            "dataset",
             "docset_index",
             "chunk_index",
             "epochs_seen",
-            "tokens_seen",
-            "docs_seen",
-            "percent_seen",
+            "dataset_tokens_seen",
+            "dataset_docs_seen",
+            "dataset_percent_seen",
             "lcg_state",
+            # "docs_seen",
         ]
 
     def _get_docid(self, i):
@@ -702,11 +732,11 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         assert (
             i <= self._len
         ), f"You have requested an illegal doc index {i}, docset length is {self._len}"
-        for shardid, min_d, max_d in self.docset:
-            docrange = max_d - min_d + 1
+        for dataset, shardid, mind, maxd in self.docset:
+            docrange = maxd - mind + 1
             cur += docrange
             if cur > i:
-                return shardid, docrange, min_d
+                return dataset, shardid, docrange, mind
 
     def _get_reader(self, path, newpath, reader):
         """
@@ -721,7 +751,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             path = newpath
         return path, reader
 
-    def _construct_chunk(self, j, doc, n_chunks):
+    def _construct_chunk(self, j, doc, n_chunks, dataset):
         """
         Grab a chunk of the desired size from the pyarrow document,
         avoiding unnecessary overhead in case of large docs
@@ -772,13 +802,13 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 if doc_index == 0:
                     self.epochs_seen += 1
                 self.docset_index = doc_index
-                # Map doc id to shard, id in file
-                shardid, docrange, mindoc = self._get_docid(doc_index)
+                # Map doc id to dataset, shard, id in file
+                dataset, shardid, docrange, mindoc = self._get_docid(doc_index)
 
                 # Read doc
-                newpath = os.path.join(self.data, shardid)
+                newpath = os.path.join(self.data, dataset, shardid)
                 path, reader = self._get_reader(path, newpath, reader)
-                # Map id in range of owned docs to new (consistently) shuffled id
+                # Map id in file to new (consistently) shuffled id
                 doclcg = self._random_map_docid(docrange)
                 docid = doclcg + mindoc
                 doc = reader.get_batch(docid)["tokens"]
@@ -794,11 +824,13 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                             self.chunk_index = j
                             # Document complete, update stats
                             if j == n_chunks - 1:
-                                self.docs_seen += 1
-                                self.percent_seen = (
-                                    self.docs_seen * 100 / (self._len + 1e-9)
+                                self.dataset_docs_seen[dataset] += 1
+                                self.dataset_percent_seen[dataset] = (
+                                    self.dataset_docs_seen[dataset]
+                                    * 100
+                                    / (self.docs_per_dataset[dataset] + 1e-9)
                                 )
-                            yield self._construct_chunk(j, doc, n_chunks)
+                            yield self._construct_chunk(j, doc, n_chunks, dataset)
 
                 # Advance RNG state
                 self.lcg_state = doclcg
@@ -806,9 +838,9 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             # Load any chunks initially skipped in first doc
             self.docset_index = docset_offset
             self.lcg_state = lcg_offset
-            shardid, docrange, mindoc = self._get_docid(docset_offset)
+            dataset, shardid, docrange, mindoc = self._get_docid(docset_offset)
             docid = self._random_map_docid(docrange) + mindoc
-            newpath = os.path.join(self.data, shardid)
+            newpath = os.path.join(self.data, dataset, shardid)
             path, reader = self._get_reader(path, newpath, reader)
             doc = reader.get_batch(docid)["tokens"]
             if len(doc) >= self.min_length:
@@ -817,18 +849,13 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 )  # add 1 for delimiter token
                 for j in range(residual_chunks):
                     self.chunk_index = j
-                    yield self._construct_chunk(j, doc, n_chunks)
+                    yield self._construct_chunk(j, doc, n_chunks, dataset)
 
     def load_state_dict(self, state_dicts, sharded_input=False):
         assert (
             self.load_worldsize == self.worldsize
-        ), "Streaming_Doc_Dataset does not support rescaling. Please use a Scalable_Shard_Dataset."
-        d = self.dataset
-        out = super().load_state_dict(state_dicts, sharded_input)
-        assert (
-            d == self.dataset
-        ), f"Dataset mismatch: checkpoint contains {self.dataset}, expected {d}"
-        return out
+        ), "Streaming_Doc_Dataset does not support rescaling"
+        return super().load_state_dict(state_dicts, sharded_input)
 
 
 class Sampling_Dataset(_Stateful_Dataset):
@@ -899,10 +926,12 @@ class Sampling_Dataset(_Stateful_Dataset):
         for i, d in enumerate(self.datasets):
             self.data.append(
                 dataset(
-                    datapath=os.path.join(datapath, d),
+                    datapath=datapath,
                     rank=rank,
                     worldsize=worldsize,
                     delimiter_token=delimiter_token,
+                    weights=None,
+                    datasets=[d],
                     verbose=verbose,
                     **kwargs,
                 )
@@ -976,7 +1005,7 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
     Args
     ----
     datapath : str
-        Absolute path to the dataset directory. Expects folder containing pyarrow shardfiles.
+        Absolute path to the dataset directory. Expects subfolders containing pyarrow shardfiles.
     rank : int
         Current worker index
     worldsize : int
@@ -1008,6 +1037,7 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
 
         super().__init__(rank, worldsize)
         self.data = []
+        self.docset: List[Any] = []
         self.n_logicals = n_logical_shards // worldsize
         self.total_shards = n_logical_shards
         self.delimiter = delimiter_token
@@ -1039,10 +1069,9 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
         # Position "state", used only for maintaining order when n_workers is unchanged
         # For scaling up or down, logical position is meaningless, and reset
         self.current_reader = None
+        self.shuffle_state = self.rank
         self.logical_shard_states = None
-        self.generator = torch.Generator().manual_seed(self.rank)
-        self.g_state = None
-        self.state_params = ["current_reader", "g_state"]
+        self.state_params = ["current_reader", "shuffle_state"]
         self.reshard_params = ["n_docs_remaining", "logical_shard_states"]
 
     def __iter__(self):
@@ -1053,9 +1082,11 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
             if self.current_reader is not None:
                 ind = self.current_reader
             else:
-                ind = torch.multinomial(
-                    torch.tensor(self.n_docs_remaining), 1, generator=self.generator
-                ).item()
+                random.seed(self.shuffle_state)
+                ind = random.choices(
+                    list(range(self.n_logicals)), weights=self.n_docs_remaining, k=1
+                )[0]
+                self.shuffle_state = (self.shuffle_state + 1) % 10000
             self.current_reader = ind
             # Read doc
             out = next(data[ind])
@@ -1071,18 +1102,11 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
             yield out
 
     def state_dict(self):
-        # Write generator state manually
-        self.g_state = self.generator.get_state()
-        # Recursive fetch
         self.logical_shard_states = [d.state_dict() for d in self.data]
         return super().state_dict()
 
     def load_state_dict(self, state_dicts, sharded_input=False):
         sharded_dicts = super().load_state_dict(state_dicts, sharded_input)
-        # Manually set generator state if it exists
-        if self.g_state is not None:
-            self.generator.set_state(self.g_state)
-        # Recursive set
         for i in range(self.n_logicals):
             self.data[i].load_state_dict([self.logical_shard_states[i]], True)
         return sharded_dicts

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -764,13 +764,12 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             else:
                 start_index -= 1
         chunk = doc.slice(start_index, n_pull).to_pylist()
+        self.dataset_tokens_seen[dataset] += len(chunk)
+        # Add bos/eos tokens if needed
         if self.bos is not None and j == 0:
             chunk = [self.bos] + chunk
         if j == n_chunks - 1:
-            chunk = chunk + [
-                self.eos
-            ]  # Add delimiter token to signify end of document (used upstream)
-        self.dataset_tokens_seen[dataset] += len(chunk)
+            chunk = chunk + [self.eos]
         return chunk
 
     def _random_map_docid(self, size):

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -555,8 +555,8 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
     worldsize : int
         Total number of workers
     delimiter_token : Any
-        Token used to indicate sequence/document breaks. Type should match data type. Required for
-        downstream sampling logic (can be removed later via Buffer_Dataset).
+        Token used to indicate sequence/document breaks. Type should match data type. Required for downstream
+        sampling logic (can be removed later via PreProcess_Dataset or Buffer_Dataset's drop_final_token flag).
     bos_token : Any | None
         Optional token used to indicate sequence/document start. Type should match data type.
     datasets : list[str] | None


### PR DESCRIPTION
Previous BOS/EOS support occurred at the line level, as in encoder-decoder training. With Llama3 BOS/EOS usage we want to extend this behavior to the document level. This PR adds support for `bos_token` flag in training and dataloading. A new unit test ensures that chunking behavior remains consistent and correct.