### PR TITLE
Loader streamlining and cleaning

### DIFF
--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -610,7 +610,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         ]
         assert len(countfiles) == 1
         doc_counts = {}
-        pathsplit = [datapath, ""]
+        pathsplit = (datapath, "")
         while len(pathsplit[1]) == 0:
             pathsplit = os.path.split(pathsplit[0])
         pardir, dataset = pathsplit

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -529,26 +529,27 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
     Pyarrow shard files are expected to hold multiple recordBatches, where each recordBatch has a "tokens"
     field consisting of a single token list. (i.e. each document is a single sequence under a "token" field,
     and the file is a list of such sequences)
-    Relies on a compiled metadata file to fetch shardfile lengths, assumes file already exists and is in
-    proper csv format (first row "dataset/filename,documents,tokens", subsequent rows these values).
+    Relies on a compiled metadata file to fetch shardfile lengths, assumes file already exists in the parent directory,
+    and is in proper csv format (first row "dataset/filename,documents,tokens", subsequent rows these values).
 
-    For each subdataset, splits shard files into x=worldsize fragments and grabs a 1/n contiguous span
-    of shard fragments (contiguous to limit file reads from cloud/disk).
+    For a single dataset directory, splits shard files into x=worldsize fragments and grabs a 1/n contiguous
+    span of shard fragments (contiguous to limit file reads from cloud/disk).
     Logs the number of documents owned from each shardfile, and relies on ZCG random bijection to
     map contiguous range of indices to shuffled, noncontiguous set of documents from each shard file.
-    Compiles oversamples across subdatasets, and shuffles the list deterministically to hop from file to file.
+    Shuffles the file list deterministically to hop from file to file.
 
     At runtime, iterates through documents in each shuffled shard file, pulling each shard on demand.
-    Shards are thus pulled no more than [oversample] times.
+    Shards are thus pulled no more than once per epoch.
     Returns documents in chunks up to size max_chunksize, and handles delimiter token placement between documents.
 
-    Streaming_Doc_Dataset uses integer weights to implement dataset weighting via oversampling per-epoch.
-    For non-epoch, percentage-based sampling, see Sampling_Dataset, which overrides this logic.
+    Streaming_Doc_Dataset grabs files from a flat directory representing a single dataset.
+    For percentage-based sampling of multiple subdatasets, see Sampling_Dataset.
     ...
     Args
     ----
     datapath : str
-        Absolute path to the dataset directory. Expects subfolders containing pyarrow shardfiles.
+        Absolute path to the dataset directory. Expects directory containing pyarrow shardfiles.
+        Parent directory should contain 'meta' folder with metadata csv file inside.
     rank : int
         Current worker index
     worldsize : int
@@ -558,10 +559,6 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         sampling logic (can be removed later via PreProcess_Dataset or Buffer_Dataset's drop_final_token flag).
     bos_token : Any | None
         Optional token used to indicate sequence/document start. Type should match data type.
-    datasets : list[str] | None
-        A list of subdatasets to draw from. If None, draws from all subfolders.
-    weights : list[int] | None
-        A list of oversample rates for each subdataset. If None, draws from all subdatasets equally.
     seed : int
         The random seed for deterministic shuffling/sharding
     min_length : int
@@ -581,8 +578,6 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         worldsize: int,
         delimiter_token: Any,
         bos_token: Optional[Any] = None,
-        datasets: Optional[List[str]] = None,
-        weights: Optional[List[int]] = None,
         seed: int = 42,
         min_length: int = 1,
         max_chunksize: int = 1024,
@@ -603,24 +598,13 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         ] = []  # map of doc indices to (shardid, min docid, max docid)
         self.docs_per_shard = {}
 
-        if weights is not None:
-            assert len(weights) == len(
-                self.datasets
-            ), f"Number of oversample weights {len(weights)} must match number of datasets {len(self.datasets)}"
-            for w in weights:
-                assert w > 0, f"Oversample rate {w} must be a positive integer"
-        self.weights = (
-            {self.datasets[i]: weights[i] for i in range(len(self.datasets))}
-            if weights is not None
-            else {d: 1 for d in self.datasets}
-        )
         # Guaranteed inconsistent shuffling across workers
         random.seed(self.seed + rank)
 
         # Gather per-file document counts from metadata count file(s)
         countfiles = [
             x
-            for x in os.listdir(os.path.join(datapath, "meta"))
+            for x in os.listdir(os.path.join(os.path.dirname(datapath), "meta"))
             if "counts" in x and "csv" in x
         ]
         assert len(countfiles) == 1
@@ -634,63 +618,57 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             reader = csv.DictReader(csvfile)
             for row in reader:
                 fullpath = row["dataset/filename"]
-                prefix = max([fullpath.find("/" + d) for d in self.datasets]) + 1
+                prefix = fullpath.find("/" + dataset) + 1
                 if prefix > 0:
                     key = fullpath[prefix:]
                     doc_counts[key] = int(row["documents"])
 
-        # Assemble document sets owned by this worker
-        for dataset in self.datasets:
-            # Listdir, assemble shardfraglist (ind -> shard, frag)
-            shards = [
-                shard
-                for shard in os.listdir(os.path.join(datapath, dataset))
-                if os.path.isfile(os.path.join(datapath, dataset, shard))
-                and "arrow" in os.path.join(datapath, dataset, shard)
-            ]
-            shards.sort()  # Ensure consistent sharding across machines
-            start_frag = (rank * worldsize * len(shards)) // worldsize
-            end_frag = ((rank + 1) * worldsize * len(shards)) // worldsize
-            shardfrags = [
-                (shards[i // worldsize], i % worldsize)
-                for i in range(start_frag, end_frag)
-            ]
+        # Assemble document set owned by this worker:
+        # listdir, assemble shardfraglist (ind -> shard, frag)
+        shards = [
+            shard
+            for shard in os.listdir(datapath)
+            if os.path.isfile(os.path.join(datapath, shard))
+            and "arrow" in os.path.join(datapath, shard)
+        ]
+        shards.sort()  # Ensure consistent sharding across machines
+        start_frag = (rank * worldsize * len(shards)) // worldsize
+        end_frag = ((rank + 1) * worldsize * len(shards)) // worldsize
+        shardfrags = [
+            (shards[i // worldsize], i % worldsize) for i in range(start_frag, end_frag)
+        ]
 
-            # Read shardfrags, assemble doc list for each file shard (aggregating over fragments):
-            ndocs = -1
-            docset = {}  # shardid -> (min docid, max docid)
-            for i, (shard, frag) in enumerate(shardfrags):
-                ndocs = doc_counts[os.path.join(dataset, shard)]
-                self.docs_per_shard[(dataset, shard)] = ndocs
-                doc_start = (ndocs * frag) // worldsize
-                doc_end = (
-                    ndocs * frag + ndocs
-                ) // worldsize - 1  # Inclusive upper bound
-                if shard not in docset:
-                    docset[shard] = [doc_start, doc_end]
-                min_d, max_d = docset[shard]
-                if doc_start < min_d:
-                    docset[shard][0] = doc_start
-                if doc_end > max_d:
-                    docset[shard][1] = doc_end
+        # Read shardfrags, assemble doc list for each file shard (aggregating over fragments):
+        ndocs = -1
+        docset = {}  # shardid -> (min docid, max docid)
+        for i, (shard, frag) in enumerate(shardfrags):
+            ndocs = doc_counts[os.path.join(dataset, shard)]
+            self.docs_per_shard[shard] = ndocs
+            doc_start = (ndocs * frag) // worldsize
+            doc_end = (ndocs * frag + ndocs) // worldsize - 1  # Inclusive upper bound
+            if shard not in docset:
+                docset[shard] = [doc_start, doc_end]
+            min_d, max_d = docset[shard]
+            if doc_start < min_d:
+                docset[shard][0] = doc_start
+            if doc_end > max_d:
+                docset[shard][1] = doc_end
 
-            # Add all of this dataset's shard entries to self.docset, with oversampling
-            doccount = 0
-            for shardid in docset:
-                for _ in range(self.weights[dataset]):
-                    min_d = docset[shardid][0]
-                    max_d = docset[shardid][1]
-                    self.docset.append((dataset, shardid, min_d, max_d))
-                    doccount += max_d - min_d + 1
-            self.docs_per_dataset[dataset] = doccount
-            self._len = sum(self.docs_per_dataset.values())
+        # Add all of this dataset's shard entries to self.docset
+        doccount = 0
+        for shardid in docset:
+            min_d = docset[shardid][0]
+            max_d = docset[shardid][1]
+            self.docset.append((shardid, min_d, max_d))
+            doccount += max_d - min_d + 1
+        self._len = doccount
 
-            if verbose:
-                logging.info(
-                    f"    Worker {rank} ingested {len(shardfrags)} shard fragments from {dataset}"
-                )
+        if verbose:
+            logging.info(
+                f"    Worker {rank} ingested {len(shardfrags)} shard fragments from {dataset}"
+            )
 
-        # Shuffle shardsets across datasets, and flatten
+        # Shuffle shard files
         if shuffle:
             random.shuffle(self.docset)
 
@@ -699,21 +677,20 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
 
         # Stats
         self.epochs_seen = -1
-        self.dataset_tokens_seen = {d: 0 for d in self.datasets}
-        self.dataset_docs_seen = {d: 0 for d in self.datasets}
-        self.dataset_percent_seen = {d: 0 for d in self.datasets}
+        self.tokens_seen = 0
+        self.docs_seen = 0
+        self.percent_seen = 0
         self.lcg_state = seed + rank
-        # self.docs_seen: Dict[Any, int] = {}  # (dataset, shard, i) -> # times seen
 
         self.state_params = [
+            "dataset",
             "docset_index",
             "chunk_index",
             "epochs_seen",
-            "dataset_tokens_seen",
-            "dataset_docs_seen",
-            "dataset_percent_seen",
+            "tokens_seen",
+            "docs_seen",
+            "percent_seen",
             "lcg_state",
-            # "docs_seen",
         ]
 
     def _get_docid(self, i):
@@ -725,11 +702,11 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         assert (
             i <= self._len
         ), f"You have requested an illegal doc index {i}, docset length is {self._len}"
-        for dataset, shardid, mind, maxd in self.docset:
-            docrange = maxd - mind + 1
+        for shardid, min_d, max_d in self.docset:
+            docrange = max_d - min_d + 1
             cur += docrange
             if cur > i:
-                return dataset, shardid, docrange, mind
+                return shardid, docrange, min_d
 
     def _get_reader(self, path, newpath, reader):
         """
@@ -744,7 +721,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             path = newpath
         return path, reader
 
-    def _construct_chunk(self, j, doc, n_chunks, dataset):
+    def _construct_chunk(self, j, doc, n_chunks):
         """
         Grab a chunk of the desired size from the pyarrow document,
         avoiding unnecessary overhead in case of large docs
@@ -795,13 +772,13 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 if doc_index == 0:
                     self.epochs_seen += 1
                 self.docset_index = doc_index
-                # Map doc id to dataset, shard, id in file
-                dataset, shardid, docrange, mindoc = self._get_docid(doc_index)
+                # Map doc id to shard, id in file
+                shardid, docrange, mindoc = self._get_docid(doc_index)
 
                 # Read doc
-                newpath = os.path.join(self.data, dataset, shardid)
+                newpath = os.path.join(self.data, shardid)
                 path, reader = self._get_reader(path, newpath, reader)
-                # Map id in file to new (consistently) shuffled id
+                # Map id in range of owned docs to new (consistently) shuffled id
                 doclcg = self._random_map_docid(docrange)
                 docid = doclcg + mindoc
                 doc = reader.get_batch(docid)["tokens"]
@@ -817,13 +794,11 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                             self.chunk_index = j
                             # Document complete, update stats
                             if j == n_chunks - 1:
-                                self.dataset_docs_seen[dataset] += 1
-                                self.dataset_percent_seen[dataset] = (
-                                    self.dataset_docs_seen[dataset]
-                                    * 100
-                                    / (self.docs_per_dataset[dataset] + 1e-9)
+                                self.docs_seen += 1
+                                self.percent_seen = (
+                                    self.docs_seen * 100 / (self._len + 1e-9)
                                 )
-                            yield self._construct_chunk(j, doc, n_chunks, dataset)
+                            yield self._construct_chunk(j, doc, n_chunks)
 
                 # Advance RNG state
                 self.lcg_state = doclcg
@@ -831,9 +806,9 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
             # Load any chunks initially skipped in first doc
             self.docset_index = docset_offset
             self.lcg_state = lcg_offset
-            dataset, shardid, docrange, mindoc = self._get_docid(docset_offset)
+            shardid, docrange, mindoc = self._get_docid(docset_offset)
             docid = self._random_map_docid(docrange) + mindoc
-            newpath = os.path.join(self.data, dataset, shardid)
+            newpath = os.path.join(self.data, shardid)
             path, reader = self._get_reader(path, newpath, reader)
             doc = reader.get_batch(docid)["tokens"]
             if len(doc) >= self.min_length:
@@ -842,13 +817,18 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
                 )  # add 1 for delimiter token
                 for j in range(residual_chunks):
                     self.chunk_index = j
-                    yield self._construct_chunk(j, doc, n_chunks, dataset)
+                    yield self._construct_chunk(j, doc, n_chunks)
 
     def load_state_dict(self, state_dicts, sharded_input=False):
         assert (
             self.load_worldsize == self.worldsize
-        ), "Streaming_Doc_Dataset does not support rescaling"
-        return super().load_state_dict(state_dicts, sharded_input)
+        ), "Streaming_Doc_Dataset does not support rescaling. Please use a Scalable_Shard_Dataset."
+        d = self.dataset
+        out = super().load_state_dict(state_dicts, sharded_input)
+        assert (
+            d == self.dataset
+        ), f"Dataset mismatch: checkpoint contains {self.dataset}, expected {d}"
+        return out
 
 
 class Sampling_Dataset(_Stateful_Dataset):
@@ -925,8 +905,6 @@ class Sampling_Dataset(_Stateful_Dataset):
                     rank=rank,
                     worldsize=worldsize,
                     delimiter_token=delimiter_token,
-                    weights=None,
-                    datasets=[d],
                     verbose=verbose,
                     **kwargs,
                 )
@@ -1000,7 +978,7 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
     Args
     ----
     datapath : str
-        Absolute path to the dataset directory. Expects subfolders containing pyarrow shardfiles.
+        Absolute path to the dataset directory. Expects folder containing pyarrow shardfiles.
     rank : int
         Current worker index
     worldsize : int
@@ -1032,7 +1010,6 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
 
         super().__init__(rank, worldsize)
         self.data = []
-        self.docset: List[Any] = []
         self.n_logicals = n_logical_shards // worldsize
         self.total_shards = n_logical_shards
         self.delimiter = delimiter_token
@@ -1064,9 +1041,10 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
         # Position "state", used only for maintaining order when n_workers is unchanged
         # For scaling up or down, logical position is meaningless, and reset
         self.current_reader = None
-        self.shuffle_state = self.rank
         self.logical_shard_states = None
-        self.state_params = ["current_reader", "shuffle_state"]
+        self.generator = torch.Generator().manual_seed(self.rank)
+        self.g_state = None
+        self.state_params = ["current_reader", "g_state"]
         self.reshard_params = ["n_docs_remaining", "logical_shard_states"]
 
     def __iter__(self):
@@ -1098,11 +1076,18 @@ class Scalable_Shard_Dataset(_Stateful_Dataset):
             yield out
 
     def state_dict(self):
+        # Write generator state manually
+        self.g_state = self.generator.get_state()
+        # Recursive fetch
         self.logical_shard_states = [d.state_dict() for d in self.data]
         return super().state_dict()
 
     def load_state_dict(self, state_dicts, sharded_input=False):
         sharded_dicts = super().load_state_dict(state_dicts, sharded_input)
+        # Manually set generator state if it exists
+        if self.g_state is not None:
+            self.generator.set_state(self.g_state)
+        # Recursive set
         for i in range(self.n_logicals):
             self.data[i].load_state_dict([self.logical_shard_states[i]], True)
         return sharded_dicts

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -839,18 +839,20 @@ class Sampling_Dataset(_Stateful_Dataset):
     the number of tokens emitted by each. Whichever loader is furthest from its target will be
     the next to pass a document.
 
-    All args except for dataset, weights and delimiter are pass-through args for the component
-    _Stateful_Datasets and are documented in the appropriate classes.
+    All args except for dataset_type, datasets, weights and delimiter are pass-through args for
+    the component _Stateful_Datasets and are documented in the appropriate classes.
     ...
     Args
     ----
-    dataset : Scalable_Shard_Dataset | Streaming_Doc_Dataset
+    dataset_type : Scalable_Shard_Dataset | Streaming_Doc_Dataset
         Underlying iterator for each desired subdataset
+    delimiter_token : Any
+        Token used to indicate sequence/document breaks. Type should match data type.
+    datasets : list[str] | None
+        A list of subdatasets to draw from. If None, draws from all subfolders of datapath.
     weights : list(float) | None
         Weights describing what percent of emitted tokens should come from each subdataset.
         Need not sum to 1. If None, tokens are drawn evenly.
-    delimiter_token : Any
-        Token used to indicate sequence/document breaks. Type should match data type.
     ...
         Pass-through args, see Streaming_Doc_Dataset or Scalable_Shard_Dataset
     """
@@ -858,7 +860,7 @@ class Sampling_Dataset(_Stateful_Dataset):
     def __init__(
         self,
         datapath: str,
-        dataset: Union[
+        dataset_type: Union[
             Type["Streaming_Doc_Dataset"],
             Type["Scalable_Shard_Dataset"],
         ],
@@ -898,7 +900,7 @@ class Sampling_Dataset(_Stateful_Dataset):
         self.data = []
         for i, d in enumerate(self.datasets):
             self.data.append(
-                dataset(
+                dataset_type(
                     datapath=os.path.join(datapath, d),
                     rank=rank,
                     worldsize=worldsize,

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -749,7 +749,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         """
         m = 2 ** math.ceil(math.log2(size))  # Round up to nearest power of 2
         a = 5  # A,C values known to work well with powers of 2 (Knuth, 1997, 3.2.1.3)
-        c = self.rank * 2 + 1
+        c = (self.rank + self.seed) * 2 + 1
         state = self.lcg_state
         while True:
             state = (a * state + c) % m

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -749,7 +749,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         """
         m = 2 ** math.ceil(math.log2(size))  # Round up to nearest power of 2
         a = 5  # A,C values known to work well with powers of 2 (Knuth, 1997, 3.2.1.3)
-        c = 1
+        c = self.rank * 2 + 1
         state = self.lcg_state
         while True:
             state = (a * state + c) % m

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -305,6 +305,7 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
             if self.ministep == self.spb:
                 self.ministep = 0
                 self.step += 1
+                print(self.rank, self.step, self.interval)
                 if self.step % self.interval == 0:
                     newpath = os.path.join(self.path, "step_" + str(self.step) + "_ckp")
                     self.save_to_path(newpath)
@@ -314,8 +315,7 @@ class Checkpoint_Dataset(_Wrapper_Dataset):
             print(msg)
 
     def save_to_path(self, path: str):
-        if self.verbose:
-            print(f"Saving dataset to {path}")
+        self.report(f"Saving dataset to {path}")
         start = time.time()
         super().save_to_path(path)
         self.report(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -669,7 +669,7 @@ def test_scalable_partitioning():
         datasets = [
             layer(src, Scalable_Shard_Dataset, i, datasets=["dataset_1"], **kwargs)
             if layer == Sampling_Dataset
-            else layer(tmpdir.name, i, **kwargs)
+            else layer(src, i, **kwargs)
             for i in range(4)
         ]  # 25 steps per epoch
         loaders = [iter(d) for d in datasets]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -661,8 +661,13 @@ def test_scalable_partitioning():
             "worldsize": 4,
             "delimiter_token": -1,
         }
+        src = (
+            tmpdir.name
+            if layer == Sampling_Dataset
+            else os.path.join(tmpdir.name, "dataset_1")
+        )
         datasets = [
-            layer(tmpdir.name, Scalable_Shard_Dataset, i, datasets=["dataset_1"], **kwargs)
+            layer(src, Scalable_Shard_Dataset, i, datasets=["dataset_1"], **kwargs)
             if layer == Sampling_Dataset
             else layer(tmpdir.name, i, **kwargs)
             for i in range(4)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -657,14 +657,14 @@ def test_scalable_partitioning():
     for layer in [Scalable_Shard_Dataset, Sampling_Dataset]:
         kwargs = {
             "n_logical_shards": 12,
-            "datasets": ["dataset_1"],
-            "weights": [1],
             "max_chunksize": 200,
+            "worldsize": 4,
+            "delimiter_token": -1,
         }
         datasets = [
-            layer(tmpdir.name, Scalable_Shard_Dataset, i, 4, -1, **kwargs)
+            layer(tmpdir.name, Scalable_Shard_Dataset, i, datasets=["dataset_1"], **kwargs)
             if layer == Sampling_Dataset
-            else layer(tmpdir.name, i, 4, -1, **kwargs)
+            else layer(tmpdir.name, i, **kwargs)
             for i in range(4)
         ]  # 25 steps per epoch
         loaders = [iter(d) for d in datasets]
@@ -735,13 +735,11 @@ def test_scalable_shard_reload_scale():
     """
     datasets = [
         Scalable_Shard_Dataset(
-            tmpdir.name,
+            os.path.join(tmpdir.name, "dataset_1"),
             i,
             2,
             -1,
             n_logical_shards=8,
-            datasets=["dataset_1"],
-            weights=[1],
             max_chunksize=40,
         )
         for i in range(2)
@@ -760,13 +758,11 @@ def test_scalable_shard_reload_scale():
 
     datasets2 = [
         Scalable_Shard_Dataset(
-            tmpdir.name,
+            os.path.join(tmpdir.name, "dataset_1"),
             i,
             4,
             -1,
             n_logical_shards=8,
-            datasets=["dataset_1"],
-            weights=[1],
             max_chunksize=40,
         )
         for i in range(4)
@@ -977,8 +973,9 @@ def test_checkpoint_reload_match():
     resume properly (matching the continued behavior of the saved ones)
     """
     datasets = [
-        Streaming_Doc_Dataset(
+        Sampling_Dataset(
             tmpdir.name,
+            Streaming_Doc_Dataset,
             i,
             3,
             -1,
@@ -1016,8 +1013,9 @@ def test_checkpoint_reload_match():
 
     # Create a second loader, pointing to first's checkpoint
     datasets2 = [
-        Streaming_Doc_Dataset(
+        Sampling_Dataset(
             tmpdir.name,
+            Streaming_Doc_Dataset,
             i,
             3,
             -1,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -691,6 +691,7 @@ def test_scalable_partitioning():
                     Scalable_Shard_Dataset,
                     i,
                     worldsize,
+                    datasets=["dataset_1"],
                     **kwargs,
                 )
                 if layer == Sampling_Dataset

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -62,19 +62,16 @@ tmpdir = generate_sequential_multidata()
 # For X_check see corresponding test_X
 
 
-def count_check(d, dataset, ntok, ndoc, alldoc, allpercent):
+def count_check(d, ntok, alldoc, allpercent):
     # Check that tokens tracked matches tokens seen, and docs tracked matches docs seen
     # d is a lambda for a fully-defined dataset (i.e. d() instantiates the dataset)
     assert (
-        d.dataset_tokens_seen[dataset] == ntok
-    ), f"Tokens tracked {d.dataset_tokens_seen[dataset]} failed to match target {ntok}"
-    # for k in d.docs_seen.keys():
-    #     if k[0] == dataset:
-    #         assert d.docs_seen[k] == ndoc, f"Document {k} appeared {d.docs_seen[k]} times rather than {ndoc}"
-    # assert (
-    #     d.dataset_docs_seen[dataset] == alldoc
-    # ), f"Total document count {d.dataset_docs_seen[dataset]} does not match target {alldoc}"
-    coverage = d.dataset_percent_seen[dataset]
+        d.tokens_seen == ntok
+    ), f"Tokens tracked {d.tokens_seen} failed to match target {ntok}"
+    assert (
+        d.docs_seen == alldoc
+    ), f"Total document count {d.docs_seen} does not match target {alldoc}"
+    coverage = d.percent_seen
     assert (
         abs(coverage - allpercent) < 1e-4
     ), f"Percent coverage {coverage} is not within 1e-4 of {allpercent}"
@@ -134,7 +131,7 @@ def single_epoch_check(d, do_countcheck=False):
 
     if do_countcheck:
         # Check state flags tracking correctly
-        count_check(dataset, "dataset_1", 100 * 100, 1, 100, 100)
+        count_check(dataset, 100 * 100, 100, 100)
 
 
 def two_epoch_check(d, do_countcheck=False):
@@ -155,7 +152,7 @@ def two_epoch_check(d, do_countcheck=False):
 
     if do_countcheck:
         # Check state flags tracking correctly
-        count_check(dataset, "dataset_1", 100 * 100 * 2, 2, 200, 200)
+        count_check(dataset, 100 * 100 * 2, 200, 200)
 
 
 def chunk_check(d, do_countcheck=False):
@@ -182,7 +179,7 @@ def chunk_check(d, do_countcheck=False):
         ), f"Chunk starting with {i * 50} failed to appear in generated data"
 
     if do_countcheck:
-        count_check(dataset, "dataset_1", 100 * 100, 1, 100, 100)
+        count_check(dataset, 100 * 100, 100, 100)
 
 
 def two_loader_check(d, do_countcheck=False):
@@ -206,8 +203,8 @@ def two_loader_check(d, do_countcheck=False):
         ), f"Line starting with {i * 100} failed to appear in generated data"
 
     if do_countcheck:
-        count_check(dataset1, "dataset_1", 50 * 100, 1, 50, 100)
-        count_check(dataset2, "dataset_1", 50 * 100, 1, 50, 100)
+        count_check(dataset1, 50 * 100, 50, 100)
+        count_check(dataset2, 50 * 100, 50, 100)
 
 
 def multi_file_check(d, do_countcheck=False):
@@ -226,7 +223,7 @@ def multi_file_check(d, do_countcheck=False):
         ), f"Line starting with {i * 50} failed to appear in generated data"
 
     if do_countcheck:
-        count_check(dataset, "dataset_2", 100 * 50, 1, 100, 100)
+        count_check(dataset, 100 * 50, 100, 100)
 
 
 def chunk_weight_check(w1, w2, d, do_countcheck=False):
@@ -250,11 +247,6 @@ def chunk_weight_check(w1, w2, d, do_countcheck=False):
             assert (
                 check[i * 50] == w1
             ), f"Chunk starting with {i * 50} appeared {check[i*50]} times rather than {w1}"
-
-    # Check state flags tracking correctly
-    if do_countcheck:
-        count_check(dataset, "dataset_1", 100 * 100 * w1, w1, 100 * w1, 100)
-        count_check(dataset, "dataset_2", 100 * 50 * w2, w2, 100 * w2, 100)
 
 
 def reload_epoch_check(loader):
@@ -333,6 +325,7 @@ def reload_single_epoch_check(loader):
     ins = []
     for _ in range(150):
         out = next(loaders2[0])
+        assert out[0] not in ins, (ins, out[0])
         ins.append(out[0])
     for _ in range(150):
         out = next(loaders2[1])
@@ -389,17 +382,15 @@ def basic_loader(
     rank=0,
     worldsize=1,
     datasets=["dataset_1"],
-    weights=[1],
     max_chunksize=1000,
     bos_token=None,
 ):
+    assert len(datasets) == 1, "Basic loader takes only 1 dataset"
     return Streaming_Doc_Dataset(
-        tmpdir.name,
+        os.path.join(tmpdir.name, datasets[0]),
         rank,
         worldsize,
         -1,
-        datasets=datasets,
-        weights=weights,
         max_chunksize=max_chunksize,
         bos_token=bos_token,
     )
@@ -424,18 +415,16 @@ def basic_scalable(
     rank=0,
     worldsize=1,
     datasets=["dataset_1"],
-    weights=[1],
     max_chunksize=1000,
     n_logical_shards=7,
     bos_token=None,
 ):
+    assert len(datasets) == 1, "Basic loader takes only 1 dataset"
     return Scalable_Shard_Dataset(
-        tmpdir.name,
+        os.path.join(tmpdir.name, datasets[0]),
         rank,
         worldsize,
         -1,
-        datasets=datasets,
-        weights=weights,
         max_chunksize=max_chunksize,
         n_logical_shards=n_logical_shards,
         bos_token=bos_token,
@@ -513,9 +502,10 @@ def test_reload_epoch():
 
 def test_reload_complete_epoch():
     # Single shard, two loaders: check that reloading mid-epoch can still complete a full epoch
-    # Skip scalable loaders as epoch 2 may sample workers differently from epoch 1
     reload_single_epoch_check(basic_loader)
+    reload_single_epoch_check(functools.partial(basic_scalable, n_logical_shards=8))
     reload_single_epoch_check(basic_sampler)
+    reload_single_epoch_check(functools.partial(basic_scalable, n_logical_shards=8))
 
 
 def test_eos_bos_chunking():
@@ -529,37 +519,9 @@ def test_eos_bos_chunking():
 # SUBDATASET WEIGHTING CHECKS
 
 
-def test_weight():
-    """
-    A test for base, non-wrapper datasets using oversampling (currently Streaming_Doc and Scalable_Shard).
-    On the full dataset, with varying weights, on a single worker: with chunksize 50, run one epoch.
-    Verify that first half of dataset_1 is replicated by dataset_2, and second half is not, with appropriate ratios.
-    """
-    w1 = [1, 2, 4]
-    w2 = [1, 3, 7]
-    for i in w1:
-        for j in w2:
-            # Test chunk weights on doc dataloader (single epoch)
-            doc_dataset = functools.partial(
-                basic_loader,
-                datasets=["dataset_1", "dataset_2"],
-                weights=[i, j],
-                max_chunksize=50,
-            )
-            chunk_weight_check(i, j, doc_dataset, True)
-            # Test chunk weights on scalable dataloader (single epoch)
-            shard_dataset = functools.partial(
-                basic_scalable,
-                datasets=["dataset_1", "dataset_2"],
-                weights=[i, j],
-                max_chunksize=50,
-            )
-            chunk_weight_check(i, j, shard_dataset)
-
-
 def test_sampler_rates():
     """
-    A test for base, non-wrapper datasets using percentage sampling (currently Sampling and Scalable_Sampling).
+    A test for Sampling_Dataset with Streaming_ and Scalable_ subdatasets.
     On the full dataset, with varying weights, on a single worker: verify that loaders pull subdatasets at regular intervals
     (verifying that they're regularly picking the most-underviewed subdataset at each step).
     """
@@ -614,12 +576,10 @@ def test_multi_reload_stress():
     # Shard doc dataset
     d1 = lambda: [
         Streaming_Doc_Dataset(
-            tmpdir.name,
+            os.path.join(tmpdir.name, "dataset_2"),
             i,
             3,
             -1,
-            datasets=["dataset_1", "dataset_2"],
-            weights=[3, 5],
             max_chunksize=17,
         )
         for i in range(3)
@@ -645,13 +605,11 @@ def test_multi_reload_stress():
     # Scalable shard dataset
     d3 = lambda: [
         Scalable_Shard_Dataset(
-            tmpdir.name,
+            os.path.join(tmpdir.name, "dataset_2"),
             i,
             3,
             -1,
             n_logical_shards=15,
-            datasets=["dataset_1", "dataset_2"],
-            weights=[3, 5],
             max_chunksize=17,
         )
         for i in range(3)
@@ -681,15 +639,10 @@ def test_multi_reload_stress():
     for d in [d1, d2, d3, d4]:
         multi_reload_stress_check(lambda: d5(d()))
 
-    # # Add PLM dataset
-    # d6 = lambda x: [PLM_Dataset(d, -3, -2) for d in x]
-    # # plm / buffer / sample / scale / doc pipeline
-    # multi_reload_stress_check(lambda: d6(d5(d4())))
-
     # Add preload buffer dataset
     d7 = lambda x: [Preload_Buffer_Dataset(d, 99) for d in x]
     # preload / sample / scale / doc pipeline
-    multi_reload_stress_check(lambda: d7(d4()))
+    multi_reload_stress_check(lambda: d7(d5(d4())))
 
 
 # SCALABLE_DATASET TESTS

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -681,26 +681,23 @@ def test_scalable_partitioning():
 
         kwargs = {
             "n_logical_shards": 12,
-            "datasets": ["dataset_1"],
-            "weights": [1],
             "max_chunksize": 200,
+            "delimiter_token": -1,
         }
         for worldsize in [1, 2, 3, 6, 12]:
             datasets = [
                 layer(
-                    tmpdir.name,
+                    src,
                     Scalable_Shard_Dataset,
                     i,
                     worldsize,
-                    -1,
                     **kwargs,
                 )
                 if layer == Sampling_Dataset
                 else layer(
-                    tmpdir.name,
+                    src,
                     i,
                     worldsize,
-                    -1,
                     **kwargs,
                 )
                 for i in range(worldsize)


### PR DESCRIPTION
- Removes oversample-based subdataset weighting (all subdataset handling now done through Sample_Dataset)
- Updates Scalable_Shard_Dataset to no longer rely on global state of `random`
- Updates LCG generator values so that different ranks and seeds follow different walks, rather than the same walk from a different starting point

Little practical effect on any existing workloads, but provides cleaner code and better sets us up for future development