### PR TITLE
More comprehensive dummy token handling

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -16,9 +16,11 @@ class train_config:
     weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"
     seq_length: int = 4096
     vocab_size: int = 32000
-    bos_token: Optional[int] = None
-    eos_token: int = 0
-    eos_present: bool = False
+    bos_token: int = None
+    eos_token: int = None
+    bol_token: int = None
+    eol_token: int = None
+    strip_tokens: str = ""
     logical_shards: int = 1024
 
     # fsdp policies

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -18,6 +18,7 @@ class train_config:
     vocab_size: int = 32000
     bos_token: Optional[int] = None
     eos_token: int = 0
+    eos_present: bool = False
     logical_shards: int = 1024
 
     # fsdp policies

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -16,10 +16,10 @@ class train_config:
     weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"
     seq_length: int = 4096
     vocab_size: int = 32000
-    bos_token: int = None
-    eos_token: int = None
-    bol_token: int = None
-    eol_token: int = None
+    bos_token: Optional[int] = None
+    eos_token: int = 0
+    bol_token: Optional[int] = None
+    eol_token: Optional[int] = None
     strip_tokens: str = ""
     logical_shards: int = 1024
 

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -70,6 +70,7 @@ def get_data_loader(cfg, rank, world_size):
         world_size,
         cfg.eos_token,
         bos_token=cfg.bos_token,
+        strip_tokens=[int(x.strip()) for x in cfg.strip_tokens.split(",") if len(x.strip())>0],
         min_length=3,
         datasets=datasets,
         weights=weights,
@@ -81,8 +82,8 @@ def get_data_loader(cfg, rank, world_size):
     data = Buffer_Dataset(
         data,
         cfg.seq_length + 1,
-        bos_token=cfg.bos_token,
-        drop_final_token=cfg.eos_token if cfg.eos_present else None,
+        bos_token=cfg.bol_token,
+        eos_token=cfg.eol_token,
         pack_hard=True,
     )
     # Shuffle outputs in length 10k buffer. Consecutive lines appear 10k steps apart on average.

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -82,6 +82,7 @@ def get_data_loader(cfg, rank, world_size):
         data,
         cfg.seq_length + 1,
         bos_token=cfg.bos_token,
+        drop_final_token=cfg.eos_token if cfg.eos_present else None,
         pack_hard=True,
     )
     # Shuffle outputs in length 10k buffer. Consecutive lines appear 10k steps apart on average.

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -580,7 +580,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         worldsize: int,
         delimiter_token: Any,
         bos_token: Optional[Any] = None,
-        strip_tokens: Optional[Set[Any]] = [],
+        strip_tokens: Optional[Set[Any]] = set(),
         datasets: Optional[List[str]] = None,
         weights: Optional[List[int]] = None,
         seed: int = 42,


### PR DESCRIPTION
1. Expose full set of available dummy tokens in config (bos,eos,bol,eol)
2. Allow user to specify which dummy tokens to drop from start/end of doc via `cfg.strip_tokens`. bos,eos,bol,eol are automatically added to this set.
3. Handle all token stripping in the base reader layer, before user-specified dummy tokens are added