### PR TITLE
update conversion script

### DIFF
--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -58,9 +58,13 @@ def convert_to_hf(model: LLaMA, model_variant, is_old_fms) -> LlamaForCausalLM:
 
             # self attn
             if is_old_fms:
-                oss_hf_layer.self_attn.q_proj.weight.copy_(fms_hf_layer.attn.query.weight)
+                oss_hf_layer.self_attn.q_proj.weight.copy_(
+                    fms_hf_layer.attn.query.weight
+                )
                 oss_hf_layer.self_attn.k_proj.weight.copy_(fms_hf_layer.attn.key.weight)
-                oss_hf_layer.self_attn.v_proj.weight.copy_(fms_hf_layer.attn.value.weight)
+                oss_hf_layer.self_attn.v_proj.weight.copy_(
+                    fms_hf_layer.attn.value.weight
+                )
             else:
                 q, k, v = torch.split(
                     fms_hf_layer.attn.in_proj.qkv_fused.weight,
@@ -108,7 +112,9 @@ def convert_to_hf(model: LLaMA, model_variant, is_old_fms) -> LlamaForCausalLM:
     return oss_hf_model
 
 
-def main(model_variant, compiled, is_old_fms, load_path, save_path, tokenizer_name_or_path):
+def main(
+    model_variant, compiled, is_old_fms, load_path, save_path, tokenizer_name_or_path
+):
     print("Initializing model...")
     llama_config = get_model_config(model_variant)
     with torch.device("meta"):

--- a/fms_to_hf.py
+++ b/fms_to_hf.py
@@ -8,9 +8,12 @@ from transformers import LlamaConfig, LlamaForCausalLM
 from fms_fsdp.utils.config_utils import get_model_config
 
 
-def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
+def convert_to_hf(model: LLaMA, model_variant, is_old_fms) -> LlamaForCausalLM:
     fms_hf_model = to_hf_api(model)
     hf_config = fms_hf_model.config
+    if "llama3" in model_variant:
+        hf_config.bos_token_id = 128000
+        hf_config.eos_token_id = 128001
     oss_hf_model = LlamaForCausalLM(
         LlamaConfig(
             vocab_size=hf_config.vocab_size,
@@ -54,14 +57,19 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
             fms_hf_layer = fms_hf_model.decoder.model.layers[i]
 
             # self attn
-            q, k, v = torch.split(
-                fms_hf_layer.attn.in_proj.qkv_fused.weight,
-                fms_hf_layer.attn.in_proj.splits,
-                dim=0,
-            )
-            oss_hf_layer.self_attn.q_proj.weight.copy_(q)
-            oss_hf_layer.self_attn.k_proj.weight.copy_(k)
-            oss_hf_layer.self_attn.v_proj.weight.copy_(v)
+            if is_old_fms:
+                oss_hf_layer.self_attn.q_proj.weight.copy_(fms_hf_layer.attn.query.weight)
+                oss_hf_layer.self_attn.k_proj.weight.copy_(fms_hf_layer.attn.key.weight)
+                oss_hf_layer.self_attn.v_proj.weight.copy_(fms_hf_layer.attn.value.weight)
+            else:
+                q, k, v = torch.split(
+                    fms_hf_layer.attn.in_proj.qkv_fused.weight,
+                    fms_hf_layer.attn.in_proj.splits,
+                    dim=0,
+                )
+                oss_hf_layer.self_attn.q_proj.weight.copy_(q)
+                oss_hf_layer.self_attn.k_proj.weight.copy_(k)
+                oss_hf_layer.self_attn.v_proj.weight.copy_(v)
             oss_hf_layer.self_attn.o_proj.weight.copy_(fms_hf_layer.attn.dense.weight)
             oss_hf_layer.self_attn.rotary_emb.inv_freqs = freqs
 
@@ -100,7 +108,7 @@ def convert_to_hf(model: LLaMA) -> LlamaForCausalLM:
     return oss_hf_model
 
 
-def main(model_variant, compiled, load_path, save_path, tokenizer_name_or_path):
+def main(model_variant, compiled, is_old_fms, load_path, save_path, tokenizer_name_or_path):
     print("Initializing model...")
     llama_config = get_model_config(model_variant)
     with torch.device("meta"):
@@ -123,7 +131,7 @@ def main(model_variant, compiled, load_path, save_path, tokenizer_name_or_path):
         model.load_state_dict(state_dict["model_state"]["_orig_mod"])
 
     print("Converting to HF model..")
-    hf_model = convert_to_hf(model)
+    hf_model = convert_to_hf(model, model_variant, is_old_fms)
     hf_model.save_pretrained(save_path)
 
     print("Copying tokenizer...")


### PR DESCRIPTION
This update addresses two things:

1. there is a breaking change in fms for [fused qkv](https://github.com/foundation-model-stack/foundation-model-stack/commit/26b293eebf3ad43654fcd9037a768a63c3a7ff5e) that changed layer names.  Since we have many trained model (and currently-training models) uses old implementation, we need back-compatibility for model conversion.
2. there is no special token in [FMS](https://github.com/foundation-model-stack/foundation-model-stack/blob/d04def43e9eb8a4e0adf7285c59dd66274e1b724/fms/models/llama.py#L39) comparing to [HF](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/configuration_llama.py#L117). so we need some ad-hoc fix on this in conversion script.

