### PR TITLE
Allow nested folders for datasets with arrow files

### DIFF
--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -625,7 +625,7 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         # Assemble document set owned by this worker:
         # listdir, assemble shardfraglist (ind -> shard, frag)
         shards = [
-            os.path.join(root, name)[len(datapath)+1:]
+            os.path.join(root, name)[len(datapath) + 1 :]
             for root, dirs, files in os.walk(datapath, topdown=False)
             for name in files
             if "arrow" in name and os.path.isfile(os.path.join(root, name))

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -627,7 +627,8 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         shards = [
             os.path.join(root, name)[len(datapath)+1:]
             for root, dirs, files in os.walk(datapath, topdown=False)
-            for name in files if "arrow" in name and os.path.isfile(os.path.join(root, name))
+            for name in files
+            if "arrow" in name and os.path.isfile(os.path.join(root, name))
         ]
         shards.sort()  # Ensure consistent sharding across machines
         start_frag = (rank * worldsize * len(shards)) // worldsize

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -625,10 +625,9 @@ class Streaming_Doc_Dataset(_Stateful_Dataset):
         # Assemble document set owned by this worker:
         # listdir, assemble shardfraglist (ind -> shard, frag)
         shards = [
-            shard
-            for shard in os.listdir(datapath)
-            if os.path.isfile(os.path.join(datapath, shard))
-            and "arrow" in os.path.join(datapath, shard)
+            os.path.join(root, name)[len(datapath)+1:]
+            for root, dirs, files in os.walk(datapath, topdown=False)
+            for name in files if "arrow" in name and os.path.isfile(os.path.join(root, name))
         ]
         shards.sort()  # Ensure consistent sharding across machines
         start_frag = (rank * worldsize * len(shards)) // worldsize


### PR DESCRIPTION
Allow nested folders with arrow files. Need to support folders with multiple levels of subfolders for datasets that contain the arrow files in the datapath