### PR TITLE
Re-add support for max_ckpt

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -8,6 +8,7 @@ class train_config:
     model_variant: str = "7b"
     ckpt_load_path: str = "/fsx/output/ckpt"
     ckpt_save_path: str = "/fsx/output/ckpt"
+    max_ckpt: int = 100
 
     # dataset and dataloader
     use_dummy_dataset: bool = False

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -166,13 +166,15 @@ def train(
         torch.cuda.reset_peak_memory_stats(device=torch.cuda.current_device())
 
         if batch_idx % cfg.checkpoint_interval == 0:
-            checkpointer.save(
+            removal = checkpointer.save(
                 batch_idx,
                 model,
                 optimizer,
                 None,
                 tokens_seen=tokens_seen + new_tokens_seen,
             )
+            if removal is not None:
+                print("    Removed old checkpoint", removal)
 
     return train_loss
 

--- a/main_training.py
+++ b/main_training.py
@@ -116,7 +116,7 @@ def main(**kwargs):
 
     # optionally load from checkpoint (when continue pretraining)
     checkpointer = Checkpointer(
-        cfg.ckpt_save_path, 1000, cfg.sharding_strategy, rank, local_rank
+        cfg.ckpt_save_path, cfg.max_ckpt, cfg.sharding_strategy, rank, local_rank
     )
     model, optimizer, _, start_step, tokens_seen = checkpointer.load(
         model,


### PR DESCRIPTION
Leverage vestigial capabilities in the checkpointer to allow removal of older checkpoints over a threshold.

- Add `cfg.max_ckpt` field, stop hardcoding it to 1000
- Update `get_oldest` function to leverage ckpt naming scheme, as `get_latest`
- Report any deleted checkpoints