### PR TITLE
 Minimal implementation of muP scaling for Llama

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -36,6 +36,7 @@ class train_config:
     learning_rate: float = 3e-4
     grad_clip_thresh: float = 1.0
     seed: int = 2023
+    reset_stepcount: bool = False
 
     # profiling
     use_profiler: bool = False

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -52,3 +52,13 @@ class train_config:
 
     # compile
     use_torch_compile: bool = True
+
+    # muP scale params
+    mup_emb_scale: float = 0
+    mup_head_scale: float = 0
+    mup_ffn_init: float = 0
+    mup_attn_init: float = 0
+    mup_attn_temp: float = 0
+    mup_0d_lr: float = 0
+    mup_1d_lr: float = 0
+    mup_2d_lr: float = 0

--- a/fms_fsdp/policies/param_init.py
+++ b/fms_fsdp/policies/param_init.py
@@ -1,18 +1,25 @@
 import torch
-from fms.modules.attention import MultiHeadAttention
+from fms.modules.attention import MultiHeadAttention, QKV
 from fms.modules.embedding import WordEmbedding
 from fms.modules.feedforward import GatedLinearUnit
 from fms.modules.layernorm import LayerNormParameterized
 
 
 # for details, read https://github.com/foundation-model-stack/fms-fsdp/issues/64
-def param_init_function(module):
-    if (
-        isinstance(module, MultiHeadAttention)
-        or isinstance(module, WordEmbedding)
-        or isinstance(module, GatedLinearUnit)
-        or isinstance(module, LayerNormParameterized)
-    ):
+def param_init_function(module, cfg):
+    scales = {
+        MultiHeadAttention: cfg.mup_attn_init,
+        QKV: cfg.mup_attn_init,
+        GatedLinearUnit: cfg.mup_ffn_init,
+        WordEmbedding: 1,
+        LayerNormParameterized: 1,
+    }
+    scale_keys = list(scales.keys())
+    scale_vals = list(scales.values())
+    type_id = [isinstance(module, x) for x in scale_keys]
+    is_resettable = sum(type_id)
+    if is_resettable:
+        module_type_id = type_id.index(True)
         module.to_empty(device=torch.cuda.current_device())
         with torch.no_grad():
-            module.reset_parameters()
+            module.reset_parameters(scale=scale_vals[module_type_id])

--- a/fms_fsdp/policies/param_init.py
+++ b/fms_fsdp/policies/param_init.py
@@ -11,7 +11,7 @@ def param_init_function(module, cfg):
         MultiHeadAttention: cfg.mup_attn_init,
         QKV: cfg.mup_attn_init,
         GatedLinearUnit: cfg.mup_ffn_init,
-        WordEmbedding: 1,
+        WordEmbedding: (cfg.mup_1d_init, cfg.mup_emb_scale, cfg.mup_head_scale),
         LayerNormParameterized: 1,
     }
     scale_keys = list(scales.keys())

--- a/fms_fsdp/policies/param_init.py
+++ b/fms_fsdp/policies/param_init.py
@@ -1,5 +1,5 @@
 import torch
-from fms.modules.attention import MultiHeadAttention, QKV
+from fms.modules.attention import QKV, MultiHeadAttention
 from fms.modules.embedding import WordEmbedding
 from fms.modules.feedforward import GatedLinearUnit
 from fms.modules.layernorm import LayerNormParameterized

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -209,7 +209,7 @@ class Checkpointer:
                         storage_reader=FileSystemReader(load_path),
                         planner=DefaultLoadPlanner(),
                     )
-                    model.load_state_dict(model_ckp["model_state"], strict=strict)
+                    model.load_state_dict(model_ckp["model_state"])
                 model.to(self.local_rank)
                 self.report(model_load_time=time.time() - model_load_time)
                 step = 0

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -208,6 +208,7 @@ class Checkpointer:
                         state_dict=model_ckp,
                         storage_reader=FileSystemReader(load_path),
                         planner=DefaultLoadPlanner(),
+                        strict=strict,
                     )
                     model.load_state_dict(model_ckp["model_state"])
                 model.to(self.local_rank)

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -208,9 +208,8 @@ class Checkpointer:
                         state_dict=model_ckp,
                         storage_reader=FileSystemReader(load_path),
                         planner=DefaultLoadPlanner(),
-                        strict=strict,
                     )
-                    model.load_state_dict(model_ckp["model_state"])
+                    model.load_state_dict(model_ckp["model_state"], strict=strict)
                 model.to(self.local_rank)
                 self.report(model_load_time=time.time() - model_load_time)
                 step = 0

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -48,14 +48,17 @@ def get_model_config(model_variant):
             hidden_grow_factor=13824 / 5120,
         )
     elif model_variant == "llama2_7b":
-        llama_config = LLaMAConfig()
+        llama_config = LLaMAConfig(
+            hidden_grow_factor=3,
+            kvheads=8,
+        )
     elif model_variant == "llama2_1.4b":
         llama_config = LLaMAConfig(
             emb_dim=2048,
             nheads=16,
             nlayers=24,
-            # hidden_grow_factor=3,
-            # kvheads=4,
+            hidden_grow_factor=3,
+            kvheads=4,
         )
     elif model_variant == "llama3_8b":
         llama_config = LLaMAConfig(

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -100,6 +100,15 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
+    elif model_variant == "llama3_1.8b_tele":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=2048,
+            nheads=32,
+            kvheads=2,
+            nlayers=24,
+            hidden_grow_factor=3.75,
+            max_expected_seq_len=4096,
     elif model_variant == "llama3_70b":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -155,7 +155,7 @@ def get_model_config(model_variant):
 
 
 def set_mup_from_cfg(job_cfg, model_cfg):
-    fields = {k:v for k,v in vars(job_cfg).items() if "mup" in k and v >= 0}
+    fields = {k:v for k,v in vars(job_cfg).items() if "mup" in k and v > 0}
     for f in fields:
         setattr(model_cfg, f, fields[f])
     return model_cfg

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -152,3 +152,10 @@ def get_model_config(model_variant):
         raise ValueError(f"model variant {model_variant} not supported.")
 
     return llama_config
+
+
+def set_mup_from_cfg(job_cfg, model_cfg):
+    fields = {k:v for k,v in vars(job_cfg).items() if "mup" in k and v >= 0}
+    for f in fields:
+        setattr(model_cfg, f, fields[f])
+    return model_cfg

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -100,7 +100,7 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
-    elif model_variant == "llama3_1.8b_tele":
+    elif model_variant == "llama3_1.8b_tele16":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=2048,
@@ -108,6 +108,16 @@ def get_model_config(model_variant):
             kvheads=2,
             nlayers=24,
             hidden_grow_factor=3.75,
+            max_expected_seq_len=4096,
+        )
+        elif model_variant == "llama3_1.8b_tele4":
+        llama_config = LLaMAConfig(
+            src_vocab_size=128256,
+            emb_dim=2048,
+            nheads=16,
+            kvheads=4,
+            nlayers=24,
+            hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
     elif model_variant == "llama3_70b":

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -104,10 +104,10 @@ def get_model_config(model_variant):
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=2048,
-            nheads=32,
-            kvheads=2,
+            nheads=16,
+            kvheads=4,
             nlayers=24,
-            hidden_grow_factor=3.75,
+            hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
     elif model_variant == "llama3_70b":

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -104,10 +104,10 @@ def get_model_config(model_variant):
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=2048,
-            nheads=16,
-            kvheads=4,
+            nheads=32,
+            kvheads=2,
             nlayers=24,
-            hidden_grow_factor=3.5,
+            hidden_grow_factor=3.75,
             max_expected_seq_len=4096,
         )
     elif model_variant == "llama3_70b":

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -142,6 +142,7 @@ def get_model_config(model_variant):
         )
     elif model_variant == "llama3_194m_4k":
         llama_config = LLaMAConfig(
+            src_vocab_size=128256,
             emb_dim=1024,
             nheads=8,
             nlayers=10,

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -54,6 +54,8 @@ def get_model_config(model_variant):
             emb_dim=2048,
             nheads=16,
             nlayers=24,
+            hidden_grow_factor=3,
+            kvheads=4,
         )
     elif model_variant == "llama3_8b":
         llama_config = LLaMAConfig(

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -155,7 +155,7 @@ def get_model_config(model_variant):
 
 
 def set_mup_from_cfg(job_cfg, model_cfg):
-    fields = {k:v for k,v in vars(job_cfg).items() if "mup" in k and v > 0}
+    fields = {k: v for k, v in vars(job_cfg).items() if "mup" in k and v > 0}
     for f in fields:
         setattr(model_cfg, f, fields[f])
     return model_cfg

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -110,7 +110,7 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.75,
             max_expected_seq_len=4096,
         )
-        elif model_variant == "llama3_1.8b_tele4":
+    elif model_variant == "llama3_1.8b_tele4":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,
             emb_dim=2048,

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -109,6 +109,7 @@ def get_model_config(model_variant):
             nlayers=24,
             hidden_grow_factor=3.75,
             max_expected_seq_len=4096,
+        )
     elif model_variant == "llama3_70b":
         llama_config = LLaMAConfig(
             src_vocab_size=128256,

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -140,6 +140,13 @@ def get_model_config(model_variant):
             hidden_grow_factor=3.5,
             max_expected_seq_len=4096,
         )
+    elif model_variant == "llama3_194m_4k":
+        llama_config = LLaMAConfig(
+            emb_dim=1024,
+            nheads=8,
+            nlayers=10,
+            max_expected_seq_len=4096,
+        )
     else:
         raise ValueError(f"model variant {model_variant} not supported.")
 

--- a/fms_fsdp/utils/config_utils.py
+++ b/fms_fsdp/utils/config_utils.py
@@ -54,8 +54,8 @@ def get_model_config(model_variant):
             emb_dim=2048,
             nheads=16,
             nlayers=24,
-            hidden_grow_factor=3,
-            kvheads=4,
+            # hidden_grow_factor=3,
+            # kvheads=4,
         )
     elif model_variant == "llama3_8b":
         llama_config = LLaMAConfig(

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -89,7 +89,6 @@ def train(
         output = output.logits if hasattr(output, "logits") else output
         ce_loss = torch.nn.CrossEntropyLoss()
         loss = ce_loss(output.view(-1, output.size(-1)), label.view(-1).long())
-        print("GOTHERE")
 
         loss.backward()
         ddp_stats[1] += model.clip_grad_norm_(cfg.grad_clip_thresh).item()

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -187,7 +187,7 @@ def setup_environ_flags():
     os.environ["NCCL_ASYNC_ERROR_HANDLING"] = str(1)
 
 
-def get_policies(cfg, rank, block):
+def get_policies(cfg, rank, block, model_cfg):
     """Get policies for mixed precision, wrapping, sharding, ac and param init function."""
 
     # mixed precision
@@ -231,7 +231,7 @@ def get_policies(cfg, rank, block):
 
     # param init function
     if cfg.low_cpu_fsdp:
-        param_init_fn = param_init_function
+        param_init_fn = partial(param_init_function, cfg=model_cfg)
     else:
         param_init_fn = None
 

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -77,6 +77,7 @@ def train(
 
     start = time.time()
     loop_start = time.time()
+    train_loss = -1
     for batch_idx, (input, label) in enumerate(train_loader, start=start_step + 1):
         if batch_idx > cfg.num_steps:
             break

--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -89,6 +89,7 @@ def train(
         output = output.logits if hasattr(output, "logits") else output
         ce_loss = torch.nn.CrossEntropyLoss()
         loss = ce_loss(output.view(-1, output.size(-1)), label.view(-1).long())
+        print("GOTHERE")
 
         loss.backward()
         ddp_stats[1] += model.clip_grad_norm_(cfg.grad_clip_thresh).item()

--- a/main_training.py
+++ b/main_training.py
@@ -138,7 +138,7 @@ def main(**kwargs):
     print("0d", type(params_0d), len(params_0d))
     print("1d", type(params_1d), len(params_1d))
     print("2d", type(params_2d), len(params_2d))
-    params_all = set(sum([params_0d, params_1d, params_2d]))
+    params_all = set(sum([params_0d, params_1d, params_2d], []))
     for p in model.parameters():
         assert p in params_all, p.shape
     optimizer = optim.AdamW(

--- a/main_training.py
+++ b/main_training.py
@@ -127,6 +127,9 @@ def main(**kwargs):
     )
     if cfg.reset_stepcount:
         start_step = 0
+        # Override loaded optim hyperparams with the current values
+        for g in optimizer.param_groups:
+            g["initial_lr"] = cfg.learning_rate
 
     # LR schedule
     warmup_interval = min(2000, cfg.num_steps // 20)

--- a/main_training.py
+++ b/main_training.py
@@ -133,7 +133,7 @@ def main(**kwargs):
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
             print(m.in_proj)
-            params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
+            params_2d += [m.dense.weight,] + [m_.weight for m_ in m.in_proj.modules()]
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]
     print("0d", type(params_0d), len(params_0d))

--- a/main_training.py
+++ b/main_training.py
@@ -132,6 +132,7 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
+            print(len(list(m.in_proj.parameters())))
             params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]

--- a/main_training.py
+++ b/main_training.py
@@ -135,6 +135,9 @@ def main(**kwargs):
         if (isinstance(m, MultiHeadAttention) or isinstance(m, GatedLinearUnit))
         and "bias" not in name
     ]
+    print("0d", type(params_0d), len(params_0d))
+    print("1d", type(params_1d), len(params_1d))
+    print("2d", type(params_2d), len(params_2d))
     params_all = set(sum([params_0d, params_1d, params_2d]))
     for p in model.parameters():
         assert p in params_all, p.shape

--- a/main_training.py
+++ b/main_training.py
@@ -125,6 +125,7 @@ def main(**kwargs):
     ]
     params_1d = []
     params_2d = []
+    print(model)
     for m in model.modules():
         if isinstance(m, WordEmbedding):
             params_1d.append(m.emb.weight)

--- a/main_training.py
+++ b/main_training.py
@@ -132,7 +132,7 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
-            print(list(m.in_proj.parameters()))
+            print(m.in_proj)
             params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]

--- a/main_training.py
+++ b/main_training.py
@@ -136,16 +136,10 @@ def main(**kwargs):
             params_2d += [m.dense.weight,] + [m_.weight for m_ in m.in_proj.modules() if isinstance(m_, nn.Linear)]
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]
-    params_all = set(sum([params_0d, params_1d, params_2d], []))
-    print("Mup:", sum([p.numel() for p in params_all]))
-    print("Base:", sum([p.numel() for p in model.parameters()]))
-    for p in model.parameters():
-        assert p in params_all, p.shape
     optimizer = optim.AdamW(
         {"params": params_0d, "lr": cfg.learning_rate * llama_config.mup_0d_lr},
         {"params": params_1d, "lr": cfg.learning_rate * llama_config.mup_1d_lr},
         {"params": params_2d, "lr": cfg.learning_rate * llama_config.mup_2d_lr},
-        lr=cfg.learning_rate,
         betas=(0.9, 0.95),
         weight_decay=0.1,
     )

--- a/main_training.py
+++ b/main_training.py
@@ -123,6 +123,7 @@ def main(**kwargs):
         optimizer,
         None,
         path=os.path.join(cfg.ckpt_load_path, "checkpoints/"),
+        strict=False,
     )
 
     # LR schedule

--- a/main_training.py
+++ b/main_training.py
@@ -3,6 +3,7 @@ import os
 
 import fire
 import torch
+import torch.nn as nn
 import torch.optim as optim
 from fms.models.llama import LLaMA, LLaMABlock
 from fms.modules.attention import MultiHeadAttention
@@ -133,7 +134,7 @@ def main(**kwargs):
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
             print(m.in_proj)
-            params_2d += [m.dense.weight,] + [m_.weight for m_ in m.in_proj.modules()]
+            params_2d += [m.dense.weight,] + [m_.weight for m_ in m.in_proj.modules() if isinstance(m_, nn.Linear)]
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]
     print("0d", type(params_0d), len(params_0d))

--- a/main_training.py
+++ b/main_training.py
@@ -133,14 +133,12 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
-            print(m.in_proj)
             params_2d += [m.dense.weight,] + [m_.weight for m_ in m.in_proj.modules() if isinstance(m_, nn.Linear)]
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]
-    print("0d", type(params_0d), len(params_0d))
-    print("1d", type(params_1d), len(params_1d))
-    print("2d", type(params_2d), len(params_2d))
     params_all = set(sum([params_0d, params_1d, params_2d], []))
+    print("Mup:", sum([p.numel() for p in params_all]))
+    print("Base:", sum([p.numel() for p in model.parameters()]))
     for p in model.parameters():
         assert p in params_all, p.shape
     optimizer = optim.AdamW(

--- a/main_training.py
+++ b/main_training.py
@@ -126,8 +126,10 @@ def main(**kwargs):
     params_2d = []
     for m in model.modules():
         if isinstance(m, WordEmbedding):
+            print("GOTHERE: 1D", [name for name,_ in m.named_parameters()])
             params_1d += [p for name, p in m.named_parameters() if "bias" not in name]
         elif isinstance(m, MultiHeadAttention) or isinstance(m, GatedLinearUnit):
+            print("GOTHERE: 2D", [name for name,_ in m.named_parameters()])
             params_2d += [p for name, p in m.named_parameters() if "bias" not in name]
     print("0d", type(params_0d), len(params_0d))
     print("1d", type(params_1d), len(params_1d))

--- a/main_training.py
+++ b/main_training.py
@@ -139,8 +139,8 @@ def main(**kwargs):
     optimizer = optim.AdamW(
         [
             {"params": params_0d, "lr": cfg.learning_rate * llama_config.mup_0d_lr},
-            {"params": params_1d, "lr": cfg.learning_rate * llama_config.mup_1d_lr},
-            {"params": params_2d, "lr": cfg.learning_rate * llama_config.mup_2d_lr},
+            {"params": params_1d, "lr": cfg.learning_rate * llama_config.mup_1d_lr / llama_config.emb_dim**.5},
+            {"params": params_2d, "lr": cfg.learning_rate * llama_config.mup_2d_lr / llama_config.emb_dim},
         ],
         betas=(0.9, 0.95),
         weight_decay=0.1,

--- a/main_training.py
+++ b/main_training.py
@@ -137,9 +137,11 @@ def main(**kwargs):
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]
     optimizer = optim.AdamW(
-        {"params": params_0d, "lr": cfg.learning_rate * llama_config.mup_0d_lr},
-        {"params": params_1d, "lr": cfg.learning_rate * llama_config.mup_1d_lr},
-        {"params": params_2d, "lr": cfg.learning_rate * llama_config.mup_2d_lr},
+        [
+            {"params": params_0d, "lr": cfg.learning_rate * llama_config.mup_0d_lr},
+            {"params": params_1d, "lr": cfg.learning_rate * llama_config.mup_1d_lr},
+            {"params": params_2d, "lr": cfg.learning_rate * llama_config.mup_2d_lr},
+        ],
         betas=(0.9, 0.95),
         weight_decay=0.1,
     )

--- a/main_training.py
+++ b/main_training.py
@@ -132,7 +132,7 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
-            print(list(m.in_proj))
+            print(list(m.in_proj.parameters()))
             params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]

--- a/main_training.py
+++ b/main_training.py
@@ -132,7 +132,7 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
-            print(len(list(m.in_proj.parameters())))
+            print(len(list(m.in_proj)))
             params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]

--- a/main_training.py
+++ b/main_training.py
@@ -45,16 +45,6 @@ def main(**kwargs):
     torch.cuda.empty_cache()
     setup_environ_flags()
 
-    # get policy
-    block = LLaMABlock
-    (
-        mixed_precision_policy,
-        wrapping_policy,
-        sharding_strategy_policy,
-        apply_selective_ac,
-        param_init_fn,
-    ) = get_policies(cfg, rank, block)
-
     # get fms model
     llama_config = get_model_config(cfg.model_variant)
     llama_config = set_mup_from_cfg(cfg, llama_config)
@@ -78,6 +68,16 @@ def main(**kwargs):
         train_loader = get_dummy_loader(cfg, rank, world_size)
     if rank == 0:
         print("Datasets constructed!")
+
+    # get policy
+    block = LLaMABlock
+    (
+        mixed_precision_policy,
+        wrapping_policy,
+        sharding_strategy_policy,
+        apply_selective_ac,
+        param_init_fn,
+    ) = get_policies(cfg, rank, block, llama_config)
 
     # FSDP
     model = FSDP(

--- a/main_training.py
+++ b/main_training.py
@@ -132,7 +132,7 @@ def main(**kwargs):
             if m.reversible and not m.tie_weights:
                 params_1d.append(m.head.weight)
         elif isinstance(m, MultiHeadAttention):
-            print(len(list(m.in_proj)))
+            print(list(m.in_proj))
             params_2d += [m.dense.weight,] + list(m.in_proj.parameters())
         elif isinstance(m, GatedLinearUnit):
             params_2d += [m.wg1_fused.weight, m.w2.weight]

--- a/main_training.py
+++ b/main_training.py
@@ -94,7 +94,7 @@ def main(**kwargs):
         auto_wrap_policy=wrapping_policy,
         mixed_precision=mixed_precision_policy,
         sharding_strategy=sharding_strategy_policy,
-        use_orig_params=cfg.use_torch_compile,
+        use_orig_params=True,
         device_id=torch.cuda.current_device(),
         limit_all_gathers=True,
         param_init_fn=param_init_fn,
@@ -125,7 +125,6 @@ def main(**kwargs):
     ]
     params_1d = []
     params_2d = []
-    print(model)
     for m in model.modules():
         if isinstance(m, WordEmbedding):
             params_1d.append(m.emb.weight)

--- a/main_training.py
+++ b/main_training.py
@@ -125,6 +125,8 @@ def main(**kwargs):
         path=os.path.join(cfg.ckpt_load_path, "checkpoints/") if not os.path.isfile(cfg.ckpt_load_path) else cfg.ckpt_load_path,
         strict=False,
     )
+    if cfg.reset_stepcount:
+        start_step = 0
 
     # LR schedule
     warmup_interval = min(2000, cfg.num_steps // 20)

--- a/main_training.py
+++ b/main_training.py
@@ -122,7 +122,7 @@ def main(**kwargs):
         model,
         optimizer,
         None,
-        path=os.path.join(cfg.ckpt_load_path, "checkpoints/"),
+        path=os.path.join(cfg.ckpt_load_path, "checkpoints/") if not os.path.isfile(cfg.ckpt_load_path) else cfg.ckpt_load_path,
         strict=False,
     )
 

--- a/main_training.py
+++ b/main_training.py
@@ -122,19 +122,13 @@ def main(**kwargs):
     params_0d = [p for name, p in model.named_parameters() if "bias" in name] + [
         m.weight for m in model.modules() if isinstance(m, LayerNormParameterized)
     ]
-    params_1d = [
-        p
-        for m in model.modules()
-        for name, p in m.named_parameters()
-        if isinstance(m, WordEmbedding) and "bias" not in name
-    ]
-    params_2d = [
-        p
-        for m in model.modules()
-        for name, p in m.named_parameters()
-        if (isinstance(m, MultiHeadAttention) or isinstance(m, GatedLinearUnit))
-        and "bias" not in name
-    ]
+    params_1d = []
+    params_2d = []
+    for m in model.modules():
+        if isinstance(m, WordEmbedding):
+            params_1d += [p for name, p in m.named_parameters() if "bias" not in name]
+        elif isinstance(m, MultiHeadAttention) or isinstance(m, GatedLinearUnit):
+            params_2d += [p for name, p in m.named_parameters() if "bias" not in name]
     print("0d", type(params_0d), len(params_0d))
     print("1d", type(params_1d), len(params_1d))
     print("2d", type(params_2d), len(params_2d))

--- a/main_training.py
+++ b/main_training.py
@@ -156,6 +156,8 @@ def main(**kwargs):
         tokens_seen,
     )
 
+    checkpointer.save_single_file(cfg.num_steps, model)
+
     dist.barrier()
     dist.destroy_process_group()
 

--- a/main_training.py
+++ b/main_training.py
@@ -11,7 +11,7 @@ from torch.optim.lr_scheduler import LambdaLR
 
 from fms_fsdp import config
 from fms_fsdp.utils.checkpointing_utils import Checkpointer
-from fms_fsdp.utils.config_utils import get_model_config, update_config
+from fms_fsdp.utils.config_utils import get_model_config, set_mup_from_cfg, update_config
 from fms_fsdp.utils.dataloader_utils import get_data_loader, get_dummy_loader
 from fms_fsdp.utils.train_utils import (
     get_policies,
@@ -57,6 +57,7 @@ def main(**kwargs):
 
     # get fms model
     llama_config = get_model_config(cfg.model_variant)
+    llama_config = set_mup_from_cfg(cfg, llama_config)
     if cfg.low_cpu_fsdp:
         with torch.device("meta"):
             model = LLaMA(llama_config)


### PR DESCRIPTION
Implement [muP scaling](https://arxiv.org/abs/2203.03466) for Llama models. Model follows muP scaling laws but introduces the minimal set of extra tunable hyperparameters that allows us to recover prior behavior - thus may not be compatible (yet) with existing muP configs. See [here](https://github.com/foundation-model-stack/foundation-model-stack/pull/304) for model-side changes.

- Introduce extra muP params to training config
- Calculate base values that allow us to mimic the training behavior of default Llama-194M config
- Adjust param_init_fn to call `reset_parameters` with appropriate scale terms
- Adjust optimizer to handle multiple `param_groups` (0d, 1d, 2d with different LR scaling on each)
- Save singlefile checkpoint at end of training run
- Add reset_stepcount option, and enable taking 0 steps (i.e. single-file checkpoint model conversion)