### PR TITLE
Support on-the-fly tokenization and HF parquet datasets

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -13,6 +13,7 @@ class train_config:
     use_dummy_dataset: bool = False
     data_path: str = "/fsx/data"
     file_type: str = "arrow"
+    col_name: str = "tokens"
     tokenizer_path: str = "/fsx/tokenizer"
     datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange"
     weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"

--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -12,6 +12,8 @@ class train_config:
     # dataset and dataloader
     use_dummy_dataset: bool = False
     data_path: str = "/fsx/data"
+    file_type: str = "arrow"
+    tokenizer_path: str = "/fsx/tokenizer"
     datasets: str = "lang=en/dataset=commoncrawl,lang=en/dataset=webhose,lang=en/dataset=github_clean,lang=de/dataset=wikipedia,lang=es/dataset=wikipedia,lang=fr/dataset=wikipedia,lang=ja/dataset=wikipedia,lang=pt/dataset=wikipedia,lang=en/dataset=wikimedia,lang=en/dataset=uspto,lang=en/dataset=pubmedcentral,lang=en/dataset=arxiv,lang=en/dataset=stackexchange"
     weights: str = "7725,500,550,28,17,22,25,8,100,500,175,250,100"
     seq_length: int = 4096

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -81,9 +81,9 @@ def get_data_loader(cfg, rank, world_size):
         cfg.file_type in _handler_map
     ), f"File type {cfg.file_type} is not recognized ({list(_handler_map.keys())})"
     if cfg.file_type == "hf_parquet":
-        filehandler = ParquetHandler(cfg.tokenizer_path)
+        filehandler = ParquetHandler(cfg.tokenizer_path, cfg.col_name)
     else:
-        filehandler = _handler_map[cfg.file_type]()
+        filehandler = _handler_map[cfg.file_type](cfg.col_name)
     # Base reader layer
     data = StreamingDocDataset(
         cfg.data_path,

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -1,14 +1,22 @@
 import torch
 
 from fms_fsdp.utils.dataset_utils import (
+    ArrowHandler,
     BufferDataset,
     CheckpointDataset,
+    ParquetHandler,
     PreloadBufferDataset,
     PreprocessDataset,
     SamplingDataset,
     ScalableShardDataset,
     StreamingDocDataset,
 )
+
+
+_handler_map = {
+    "arrow": ArrowHandler,
+    "hf_parquet": ParquetHandler,
+}
 
 
 def get_dummy_loader(cfg, rank, world_size):
@@ -69,11 +77,19 @@ def get_data_loader(cfg, rank, world_size):
         int(x.strip()) for x in cfg.strip_tokens.split(",") if len(x.strip()) > 0
     ]
     droplist = droplist + [cfg.bos_token, cfg.eos_token, cfg.bol_token, cfg.eol_token]
+    assert (
+        cfg.file_type in _handler_map
+    ), f"File type {cfg.file_type} is not recognized ({list(_handler_map.keys())})"
+    if cfg.file_type == "hf_parquet":
+        filehandler = ParquetHandler(cfg.tokenizer_path)
+    else:
+        filehandler = _handler_map[cfg.file_type]()
     # Base reader layer
     data = StreamingDocDataset(
         cfg.data_path,
         rank,
         world_size,
+        filehandler,
         cfg.eos_token,
         bos_token=cfg.bos_token,
         strip_tokens=set(droplist),

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -315,6 +315,7 @@ class ArrowHandler(_ShardFileHandler):
     the entire document or shard file, allowing for graceful handling of large documents.
     Non-standard data format, though.
     """
+
     def __init__(self, col_name: str = "tokens"):
         self.col_name = col_name
 

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -5,13 +5,13 @@ import os
 import random
 import time
 from copy import deepcopy
-from typing import Any, Callable, List, Optional, Set, Type, Union
+from typing import Any, Callable, List, Optional, Set, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
 import torch.utils.data as data
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer  # type: ignore
 
 from fms_fsdp.utils.checkpointing_utils import get_latest
 

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -431,12 +431,18 @@ class CheckpointDataset(_WrapperDataset):
             save_path = load_path
         else:
             save_path = os.path.join(save_path, "checkpoints")
+        self.load_path = load_path
         self.path = save_path
         self.step = 0
         self.ministep = 0
-        self.load_from_path(load_path)
+
+    def setup(self):
+        if not self.is_setup:
+            super().setup()
+            self.load_from_path(self.load_path)
 
     def __iter__(self):
+        self.setup()
         dataset = iter(self.dataset)
         while True:
             yield next(dataset)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -914,6 +914,7 @@ def test_checkpoint_reload_match():
         CheckpointDataset(x, os.path.join(tmpdir.name, "ckp_test"), 1000, 2)
         for x in datasets2
     ]
+    [d.setup() for d in datasets2]
 
     # Assert checkpoints have loaded correctly
     for d in datasets2:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -573,6 +573,7 @@ def test_multi_reload_stress():
             os.path.join(tmpdir.name, "dataset_2"),
             i,
             3,
+            ArrowHandler(),
             -1,
             max_chunksize=17,
         )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -390,6 +390,7 @@ def basic_loader(
         os.path.join(tmpdir.name, datasets[0]),
         rank,
         worldsize,
+        ArrowHandler(),
         -1,
         max_chunksize=max_chunksize,
         bos_token=bos_token,


### PR DESCRIPTION
Pull out hard-coded dependency on non-standard pyarrow data format. Base `StreamingDocDataset` now takes a new FileHandler class, implementing `open`, `length`, `get`, and `slice` operations for a given shard file type. Pyarrow shards work exactly as before via `ArrowHandler`, but we also introduce a `ParquetHandler` for indexable raw-text parquet files, commonly used in HF datasets. 

Added a new `--tokenizer_path` flag to support on-the-fly tokenization of said HF parquet files. Initial implementation caused no slowdown in testing.

Code presented here ~~is not yet tested.~~ runs on Vela. Builds off of #99. 