### PR TITLE
Support n_workers > 1

### DIFF
--- a/fms_fsdp/config/training.py
+++ b/fms_fsdp/config/training.py
@@ -25,6 +25,7 @@ class train_config:
     eol_token: Optional[int] = None
     strip_tokens: str = ""
     logical_shards: int = 1024
+    num_workers: int = 1
 
     # fsdp policies
     sharding_strategy: str = "hsdp"

--- a/fms_fsdp/utils/dataloader_utils.py
+++ b/fms_fsdp/utils/dataloader_utils.py
@@ -131,7 +131,9 @@ def get_data_loader(cfg, rank, world_size):
         cfg.batch_size,
         cfg.ckpt_save_path,
     )
-    return torch.utils.data.DataLoader(data, num_workers=1, batch_size=cfg.batch_size)
+    return torch.utils.data.DataLoader(
+        data, num_workers=cfg.num_workers, batch_size=cfg.batch_size
+    )
 
 
 def parse_data_args(datas, weights):

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -1126,7 +1126,9 @@ class ScalableShardDataset(_WrapperDataset):
             logicals = list(range(n_logical_shards))
             self.logicals_owned = _shard_partition(logicals, self.rank, self.worldsize)
             self.n_logicals = n_logical_shards // self.worldsize
-            assert len(self.logicals_owned) == self.n_logicals
+            assert (
+                len(self.logicals_owned) == self.n_logicals
+            ), "(world size * num workers) does not divide logical shards evenly"
 
             # Build logical shards
             for i in range(self.n_logicals):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -967,13 +967,11 @@ def test_multiprocess_epoch():
     Check that ScalableShardDataset partitions correctly over various worldsize / n_worker
     combinations. A single epoch should contain each datapoint exactly once.
     """
-    n_workers = [0, 1, 2]
+    n_workers = [0, 2]
     worldsizes = [2, 5]
-    logicals = [50, 100]
     for n in n_workers:
         for w in worldsizes:
-            for l in logicals:
-                d = [basic_scalable(i, w, n_logical_shards=l) for i in range(w)]
-                # Add a dummy wrapper (append some pads) to test correct wrapper behavior
-                d = [BufferDataset(x, 110, False, pad_token=-1) for x in d]
-                single_epoch_loader_worker_check(d, n)
+            d = [basic_scalable(i, w, n_logical_shards=20) for i in range(w)]
+            # Add a dummy wrapper (append some pads) to test correct wrapper behavior
+            d = [BufferDataset(x, 110, False, pad_token=-1) for x in d]
+            single_epoch_loader_worker_check(d, n)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -967,7 +967,7 @@ def test_multiprocess_epoch():
     Check that ScalableShardDataset partitions correctly over various worldsize / n_worker
     combinations. A single epoch should contain each datapoint exactly once.
     """
-    n_workers = [0, 1, 5]
+    n_workers = [0, 1, 2]
     worldsizes = [2, 5]
     logicals = [50, 100]
     for n in n_workers:


### PR DESCRIPTION
Current dataloader supports asynchronous parallel data loading, but only via a single extra process (`n_workers=1`). This PR extends the recursive `setup()` method to handle multi-process parallel asynchronous data loading, by incorporating local rank and worldsize and recalculating the global rank and worldsize used for sharding etc.

Add a new unit test to ensure consistent behavior across different worldsizes / num_workers. 

Backwards compatible, default training behavior does not change.