### PR TITLE
Skip countfile search if meta folder does not exist

### DIFF
--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -847,11 +847,13 @@ class StreamingDocDataset(_StatefulDataset):
 
             # Assemble length of each owned shard file
 
-            countfiles = [
-                x
-                for x in os.listdir(os.path.join(pardir, "meta"))
-                if "counts" in x and "csv" in x
-            ]
+            countfiles = []
+            if os.path.exists(os.path.join(pardir, "meta")):
+                countfiles = [
+                    x
+                    for x in os.listdir(os.path.join(pardir, "meta"))
+                    if "counts" in x and "csv" in x
+                ]
             doc_counts = {}
             if len(countfiles) > 0:
                 # Count file exists, use it


### PR DESCRIPTION
The dataloader currently supports no-countfile setups by searching for the countfiles in the meta folder, and if none are found, taking an alternative approach. However, this still assumes that the meta folder exists, which is likely not to be the case when a countfile is absent. This PR skips the countfile search if the meta folder does not exist. 