### PR TITLE
Correct no countfile / parquet combo handling

### DIFF
--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -870,9 +870,7 @@ class StreamingDocDataset(_StatefulDataset):
                 # Count file does not exist, touch every owned file for length
                 unique_shardfiles = set(shard for shard, frag in shardfrags)
                 doc_counts = {
-                    shard: pa.ipc.open_file(
-                        pa.memory_map(os.path.join(datapath, shard))
-                    ).num_record_batches
+                    shard: self.filehandler.length(os.path.join(datapath, shard))
                     for shard in unique_shardfiles
                 }
 


### PR DESCRIPTION
Bug fix: looks like a conflict got resolved incorrectly, or we just missed a use/test case. The no-countfile length retrieval logic is still hardcoded to the pyarrow format rather than calling the appropriate `filehandler.length()` function.