### PR TITLE
 Informative error msg for dataloading an empty dir

### DIFF
--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -1182,6 +1182,7 @@ class ScalableShardDataset(_WrapperDataset):
             if self.current_reader is not None:
                 ind = self.current_reader
             else:
+                assert sum(self.n_docs_remaining) > 0, f"No documents detected in {self.datapath}"
                 ind = torch.multinomial(
                     torch.tensor(self.n_docs_remaining, dtype=torch.float),
                     1,

--- a/fms_fsdp/utils/dataset_utils.py
+++ b/fms_fsdp/utils/dataset_utils.py
@@ -1182,7 +1182,9 @@ class ScalableShardDataset(_WrapperDataset):
             if self.current_reader is not None:
                 ind = self.current_reader
             else:
-                assert sum(self.n_docs_remaining) > 0, f"No documents detected in {self.datapath}"
+                assert (
+                    sum(self.n_docs_remaining) > 0
+                ), f"No documents detected in {self.datapath}"
                 ind = torch.multinomial(
                     torch.tensor(self.n_docs_remaining, dtype=torch.float),
                     1,


### PR DESCRIPTION
The `ScalableShardDataset` assumes that at least one of its sub-loaders owns at least one document, and when this is not the case, it errors out via the `torch.multinomial()` call. The resulting error message is not particularly clear or useful, so add a simple assert message to catch this case and inform the user that none of the workers were able to find any documents to load.