### PR TITLE
Typo `os.path.is_file` instead of `os.path.isfile`

### DIFF
--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -114,7 +114,7 @@ class Checkpointer:
             ckp_to_remove = Path(
                 get_oldest(self.ckp_path, qualifier=lambda x: "tmp" in x)
             )
-            if os.path.is_file(ckp_to_remove):
+            if os.path.isfile(ckp_to_remove):
                 ckp_to_remove.unlink()
             else:
                 shutil.rmtree(ckp_to_remove)


### PR DESCRIPTION
There seems to be a typo in the `Checkpointer` class. The `_cleanup` method calls `os.path.is_file` instead of `os.path.isfile`.