### PR TITLE
Final singlefile checkpoint saves one folder up

### DIFF
--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -324,7 +324,7 @@ class Checkpointer:
     ):
         # Note: metadata kwargs cannot contain any of:
         # (step, model)
-        save_name = os.path.join(self.ckp_path, "step_" + str(step) + "_ckp.pth")
+        save_name = os.path.join(self.ckp_path[:-12], "step_" + str(step) + "_ckp.pth")
         save_time = time.time()
         with FSDP.state_dict_type(
             model,

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -324,7 +324,9 @@ class Checkpointer:
     ):
         # Note: metadata kwargs cannot contain any of:
         # (step, model)
-        save_name = os.path.join(self.ckp_path[:-12], "step_" + str(step) + "_ckp.pth")
+        pth_path = os.path.join(self.ckp_path[:-12], "pth")
+        os.makedirs(pth_path, exist_ok=True)
+        save_name = os.path.join(pth_path, "step_" + str(step) + "_ckp.pth")
         save_time = time.time()
         with FSDP.state_dict_type(
             model,

--- a/fms_fsdp/utils/checkpointing_utils.py
+++ b/fms_fsdp/utils/checkpointing_utils.py
@@ -324,9 +324,9 @@ class Checkpointer:
     ):
         # Note: metadata kwargs cannot contain any of:
         # (step, model)
-        pth_path = os.path.join(self.ckp_path[:-12], "pth")
+        pth_path = os.path.join(self.ckp_path[:-12], "pth", "step_" + str(step))
         os.makedirs(pth_path, exist_ok=True)
-        save_name = os.path.join(pth_path, "step_" + str(step) + "_ckp.pth")
+        save_name = os.path.join(pth_path, "consolidated.00.pth")
         save_time = time.time()
         with FSDP.state_dict_type(
             model,


### PR DESCRIPTION
Addresses #126 

Adjusts the save location of final single-file checkpoint to be one folder up (directly in the specified ckp directory, rather than under the 'checkpoints' subfolder). That way the dataloader checkpointer only has to deal with distributed checkpoint folders.