### PR TITLE
fix: free logits

### DIFF
--- a/fms_fsdp/utils/train_utils.py
+++ b/fms_fsdp/utils/train_utils.py
@@ -89,6 +89,8 @@ def train(
         output = output.logits if hasattr(output, "logits") else output
         ce_loss = torch.nn.CrossEntropyLoss()
         loss = ce_loss(output.view(-1, output.size(-1)), label.view(-1).long())
+        # Delete output to free large memory cost from logits
+        del output
 
         loss.backward()
         ddp_stats[1] += model.clip_grad_norm_(cfg.grad_clip_thresh).item()


### PR DESCRIPTION
Currently the training code holds onto a reference to `outputs`, the model logits, throughout the training loop. This means that references to the logits from the previous iteration are still alive while progressing through the next iteration, and so their CUDA memory cannot be freed and re-used. Logits are very memory intensive: for a 128k vocab size and 4k seqlen, bfloat16 logits cost 1 GiB * batch_size, so this should be avoided.

This PR deletes the logits reference as soon as possible, thereby freeing up memory.